### PR TITLE
Fix undefined orders relationship in branch model

### DIFF
--- a/app/Models/Branch.php
+++ b/app/Models/Branch.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Branch extends Model
 {
@@ -29,6 +30,24 @@ class Branch extends Model
     public function users(): HasMany
     {
         return $this->hasMany(User::class);
+    }
+
+    /**
+     * Get the orders associated with this branch.
+     */
+    public function orders(): HasMany
+    {
+        return $this->hasMany(Order::class);
+    }
+
+    /**
+     * Get the products available at this branch.
+     */
+    public function products(): BelongsToMany
+    {
+        return $this->belongsToMany(Product::class, 'product_branches')
+                    ->withPivot(['selling_price', 'current_stock', 'is_available_online'])
+                    ->withTimestamps();
     }
 
     /**


### PR DESCRIPTION
Add `orders()` and `products()` relationships to the `Branch` model to resolve `BadMethodCallException` on the dashboard.

The `DashboardController` was attempting to use `withCount(['orders', 'products'])` on the `Branch` model, but these relationship methods were not defined, leading to a `BadMethodCallException`. This PR defines the missing `hasMany` relationship for `orders` and `belongsToMany` for `products`.

---
<a href="https://cursor.com/background-agent?bcId=bc-deb33d15-934e-495b-9f73-9cf44ce26784">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-deb33d15-934e-495b-9f73-9cf44ce26784">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

