### PR TITLE
Fix missing role class binding

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\CheckRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //


### PR DESCRIPTION
Register `CheckRole` middleware as `role` alias to resolve `BindingResolutionException`.

The application was throwing a `Target class [role] does not exist` error when accessing routes protected by the `role` middleware because the middleware alias was not defined in `bootstrap/app.php`.

---
<a href="https://cursor.com/background-agent?bcId=bc-41cde456-e9de-4419-b53a-78aad7d4793e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41cde456-e9de-4419-b53a-78aad7d4793e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

