### PR TITLE
Fix database seeding errors after git pull

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,30 +15,17 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // Call existing seeders in order
+        // Use the comprehensive LoginSystemSeeder
         $this->call([
-            RoleSeeder::class,
-            BranchSeeder::class,
-            AdminUserSeeder::class,
+            LoginSystemSeeder::class,
         ]);
 
-        // Add a simple test user for easy login testing
-        $adminRole = Role::where('name', 'admin')->first();
-        $mainBranch = Branch::first();
-
-        if ($adminRole && $mainBranch) {
-            // Check if test user already exists
-            if (!User::where('email', 'test@foodcompany.com')->exists()) {
-                User::create([
-                    'name' => 'Test User',
-                    'email' => 'test@foodcompany.com',
-                    'phone' => '+1234567899',
-                    'password' => Hash::make('password123'),
-                    'role_id' => $adminRole->id,
-                    'branch_id' => $mainBranch->id,
-                    'is_active' => true,
-                ]);
-            }
-        }
+        // Optionally call other data seeders if needed
+        // $this->call([
+        //     BasicDataSeeder::class,
+        //     CitySeeder::class,
+        //     CityProductPricingSeeder::class,
+        //     EnhancedSystemSeeder::class,
+        // ]);
     }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -52,7 +52,7 @@ class RoleSeeder extends Seeder
             
             // Financial Management
             ['name' => 'finance.view', 'display_name' => 'View Finance', 'description' => 'Can view financial data', 'module' => 'finance'],
-            ['name' => 'finance.edit', 'description' => 'Can edit financial data', 'module' => 'finance'],
+            ['name' => 'finance.edit', 'display_name' => 'Edit Finance', 'description' => 'Can edit financial data', 'module' => 'finance'],
             ['name' => 'finance.reports', 'display_name' => 'Financial Reports', 'description' => 'Can view financial reports', 'module' => 'finance'],
             
             // Analytics & Reports
@@ -61,7 +61,10 @@ class RoleSeeder extends Seeder
         ];
 
         foreach ($permissions as $permission) {
-            Permission::create($permission);
+            Permission::firstOrCreate(
+                ['name' => $permission['name']], 
+                $permission
+            );
         }
 
         // Create roles with their permissions
@@ -114,11 +117,14 @@ class RoleSeeder extends Seeder
             $permissions = $roleData['permissions'];
             unset($roleData['permissions']);
             
-            $role = Role::create($roleData);
+            $role = Role::firstOrCreate(
+                ['name' => $roleData['name']], 
+                $roleData
+            );
             
-            // Attach permissions to role
+            // Sync permissions to role (this will replace existing permissions)
             $permissionModels = Permission::whereIn('name', $permissions)->get();
-            $role->permissions()->attach($permissionModels);
+            $role->permissions()->sync($permissionModels);
         }
     }
 }


### PR DESCRIPTION
Refactor database seeding to use the comprehensive `LoginSystemSeeder` and make `RoleSeeder` idempotent to prevent duplicate entry errors.

The previous seeding process caused `UniqueConstraintViolationException` when `php artisan db:seed` was run multiple times, as `RoleSeeder` attempted to create permissions and roles that already existed. This PR updates `RoleSeeder` to use `firstOrCreate` and `sync` to handle existing entries gracefully and configures `DatabaseSeeder` to primarily use the new `LoginSystemSeeder` for a complete and robust initial setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-c44770ff-5774-4b53-ade2-6d751047ec2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c44770ff-5774-4b53-ade2-6d751047ec2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

