### PR TITLE
Fix cities table seeding error

### DIFF
--- a/database/migrations/2025_09_04_052325_create_cities_table.php
+++ b/database/migrations/2025_09_04_052325_create_cities_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('state')->nullable();
+            $table->string('postal_code')->nullable(); // Postal/ZIP code
             $table->string('country')->default('India');
             $table->string('code', 10)->unique(); // City code like 'DEL', 'MUM', 'BLR'
             $table->decimal('delivery_charge', 8, 2)->default(0);

--- a/database/seeders/LoginSystemSeeder.php
+++ b/database/seeders/LoginSystemSeeder.php
@@ -18,9 +18,9 @@ class LoginSystemSeeder extends Seeder
     {
         // Create cities first
         $cities = [
-            ['name' => 'Downtown', 'state' => 'State1', 'postal_code' => '12345'],
-            ['name' => 'Uptown', 'state' => 'State1', 'postal_code' => '12346'],
-            ['name' => 'Suburb', 'state' => 'State2', 'postal_code' => '54321'],
+            ['name' => 'Downtown', 'state' => 'State1', 'postal_code' => '12345', 'code' => 'DT'],
+            ['name' => 'Uptown', 'state' => 'State1', 'postal_code' => '12346', 'code' => 'UT'],
+            ['name' => 'Suburb', 'state' => 'State2', 'postal_code' => '54321', 'code' => 'SB'],
         ];
 
         foreach ($cities as $cityData) {


### PR DESCRIPTION
Add `postal_code` column to `cities` migration and `code` field to `LoginSystemSeeder` to fix database seeding errors.

The `postal_code` column was missing from the `cities` table, causing a `Column not found` error during seeding. The `code` field was also added to the seeder to match the migration's unique requirement, preventing a subsequent error.

---
<a href="https://cursor.com/background-agent?bcId=bc-2813523b-6fa2-4106-95c4-457f8e035592">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2813523b-6fa2-4106-95c4-457f8e035592">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

