### PR TITLE
Fix pos details date formatting error

### DIFF
--- a/resources/views/admin/branches/pos-details.blade.php
+++ b/resources/views/admin/branches/pos-details.blade.php
@@ -72,8 +72,8 @@
                     <tr>
                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">#{{ $session->id }}</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $session->user->name ?? 'N/A' }}</td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $session->start_time->format('M d, Y H:i') }}</td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $session->end_time ? $session->end_time->format('M d, Y H:i') : 'Active' }}</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $session->started_at ? $session->started_at->format('M d, Y H:i') : 'N/A' }}</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $session->ended_at ? $session->ended_at->format('M d, Y H:i') : 'Active' }}</td>
                         <td class="px-6 py-4 whitespace-nowrap">
                             <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium
                                 {{ $session->status === 'active' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800' }}">


### PR DESCRIPTION
Fix 'Call to a member function format() on null' error in POS details by using correct session timestamp fields and adding null checks.

The error occurred because `pos-details.blade.php` was attempting to format `$session->start_time` and `$session->end_time`, but the `POS session` model uses `started_at` and `ended_at`. This resulted in `null` values being passed to the `format()` method. The PR updates the template to use the correct field names and includes null checks for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-36d49295-7b80-4832-a003-f667439a1c70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36d49295-7b80-4832-a003-f667439a1c70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

