### PR TITLE
Handle duplicate pos terminal id error

### DIFF
--- a/app/Http/Controllers/Web/AdminBranchManagementController.php
+++ b/app/Http/Controllers/Web/AdminBranchManagementController.php
@@ -56,7 +56,7 @@ class AdminBranchManagementController extends Controller
             'outlet_type' => 'required|in:retail,wholesale,hybrid',
             'operating_hours' => 'nullable|array',
             'pos_enabled' => 'boolean',
-            'pos_terminal_id' => 'nullable|string|max:50',
+            'pos_terminal_id' => 'nullable|string|max:50|unique:branches,pos_terminal_id',
             'is_active' => 'boolean',
         ]);
 
@@ -129,7 +129,7 @@ class AdminBranchManagementController extends Controller
             'outlet_type' => 'required|in:retail,wholesale,hybrid',
             'operating_hours' => 'nullable|array',
             'pos_enabled' => 'boolean',
-            'pos_terminal_id' => 'nullable|string|max:50',
+            'pos_terminal_id' => ['nullable', 'string', 'max:50', Rule::unique('branches')->ignore($branch->id)],
             'is_active' => 'boolean',
         ]);
 

--- a/app/Http/Controllers/Web/BranchManagementController.php
+++ b/app/Http/Controllers/Web/BranchManagementController.php
@@ -73,7 +73,7 @@ class BranchManagementController extends Controller
             'outlet_type' => 'required|in:restaurant,takeaway,delivery_only,hybrid',
             'operating_hours' => 'nullable|array',
             'pos_enabled' => 'boolean',
-            'pos_terminal_id' => 'nullable|string|max:50',
+            'pos_terminal_id' => 'nullable|string|max:50|unique:branches,pos_terminal_id',
         ]);
 
         if ($validator->fails()) {
@@ -178,7 +178,7 @@ class BranchManagementController extends Controller
             'outlet_type' => 'required|in:restaurant,takeaway,delivery_only,hybrid',
             'operating_hours' => 'nullable|array',
             'pos_enabled' => 'boolean',
-            'pos_terminal_id' => 'nullable|string|max:50',
+            'pos_terminal_id' => ['nullable', 'string', 'max:50', Rule::unique('branches')->ignore($branch->id)],
             'is_active' => 'boolean',
         ]);
 

--- a/database/seeders/InventorySystemSeeder.php
+++ b/database/seeders/InventorySystemSeeder.php
@@ -54,7 +54,7 @@ class InventorySystemSeeder extends Seeder
                 'city_id' => City::where('name', 'Mumbai')->first()->id,
                 'outlet_type' => 'retail',
                 'pos_enabled' => true,
-                'pos_terminal_id' => 'POS001',
+                'pos_terminal_id' => 'POS101',
             ],
             [
                 'name' => 'Branch Store - Delhi',
@@ -65,11 +65,25 @@ class InventorySystemSeeder extends Seeder
                 'city_id' => City::where('name', 'Delhi')->first()->id,
                 'outlet_type' => 'retail',
                 'pos_enabled' => true,
-                'pos_terminal_id' => 'POS002',
+                'pos_terminal_id' => 'POS102',
             ],
         ];
 
         foreach ($branches as $branchData) {
+            // Check if a branch with this pos_terminal_id already exists
+            if (isset($branchData['pos_terminal_id'])) {
+                $existingBranch = Branch::where('pos_terminal_id', $branchData['pos_terminal_id'])->first();
+                if ($existingBranch && $existingBranch->code !== $branchData['code']) {
+                    // Generate a unique pos_terminal_id if there's a conflict
+                    $counter = 1;
+                    $basePosId = $branchData['pos_terminal_id'];
+                    do {
+                        $branchData['pos_terminal_id'] = $basePosId . '_' . $counter;
+                        $counter++;
+                    } while (Branch::where('pos_terminal_id', $branchData['pos_terminal_id'])->exists());
+                }
+            }
+            
             Branch::firstOrCreate(['code' => $branchData['code']], $branchData);
         }
 

--- a/database/seeders/LoginSystemSeeder.php
+++ b/database/seeders/LoginSystemSeeder.php
@@ -133,6 +133,20 @@ class LoginSystemSeeder extends Seeder
         ];
 
         foreach ($branches as $branchData) {
+            // Check if a branch with this pos_terminal_id already exists
+            if (isset($branchData['pos_terminal_id'])) {
+                $existingBranch = Branch::where('pos_terminal_id', $branchData['pos_terminal_id'])->first();
+                if ($existingBranch && $existingBranch->code !== $branchData['code']) {
+                    // Generate a unique pos_terminal_id if there's a conflict
+                    $counter = 1;
+                    $basePosId = $branchData['pos_terminal_id'];
+                    do {
+                        $branchData['pos_terminal_id'] = $basePosId . '_' . $counter;
+                        $counter++;
+                    } while (Branch::where('pos_terminal_id', $branchData['pos_terminal_id'])->exists());
+                }
+            }
+            
             Branch::firstOrCreate(['code' => $branchData['code']], $branchData);
         }
 


### PR DESCRIPTION
Prevent duplicate `pos_terminal_id` entries by updating seeder values, adding unique generation logic, and implementing controller validation.

The `SQLSTATE[23000]` error occurred because both `InventorySystemSeeder` and `LoginSystemSeeder` were trying to create branches with the same `pos_terminal_id` values ('POS001', 'POS002'), violating a unique constraint. This PR resolves these seeder conflicts and adds unique validation to the `BranchManagementController` and `AdminBranchManagementController` to prevent duplicate `pos_terminal_id` entries from the web interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-8723dfd4-9d52-4b15-8229-1932167947db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8723dfd4-9d52-4b15-8229-1932167947db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

