### PR TITLE
Fix database migration errors

### DIFF
--- a/database/migrations/2025_01_17_000001_enhance_stock_movements_and_add_missing_fields.php
+++ b/database/migrations/2025_01_17_000001_enhance_stock_movements_and_add_missing_fields.php
@@ -164,6 +164,7 @@ return new class extends Migration
 
         Schema::table('orders', function (Blueprint $table) {
             if (Schema::hasColumn('orders', 'created_by')) {
+                $table->dropForeign(['created_by']);
                 $table->dropColumn('created_by');
             }
         });

--- a/database/migrations/2025_01_18_000001_create_advanced_stock_management_system.php
+++ b/database/migrations/2025_01_18_000001_create_advanced_stock_management_system.php
@@ -152,7 +152,7 @@ return new class extends Migration
             $table->decimal('financial_impact', 12, 2)->default(0); // Financial impact
             $table->timestamps();
 
-            $table->index(['stock_reconciliation_id', 'product_id']);
+            $table->index(['stock_reconciliation_id', 'product_id'], 'stock_recon_items_recon_id_product_id_idx');
         });
 
         // Create financial impact tracking table

--- a/database/migrations/2025_09_04_052853_add_pos_session_to_orders_table.php
+++ b/database/migrations/2025_09_04_052853_add_pos_session_to_orders_table.php
@@ -23,6 +23,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('orders', function (Blueprint $table) {
+            $table->dropIndex(['pos_session_id', 'created_at']);
             $table->dropForeign(['pos_session_id']);
             $table->dropColumn(['pos_session_id']);
         });


### PR DESCRIPTION
Fixes three Laravel migration issues: a MySQL index name too long error and two foreign key/index constraint errors during rollbacks.

The index name `stock_reconciliation_items_stock_reconciliation_id_product_id_index` exceeded MySQL's 64-character limit. Additionally, two rollback methods failed because foreign key constraints or indexes were not dropped before their respective columns, leading to `Cannot drop index` or `Cannot drop column` errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-31e6fb11-c309-49c7-9673-910c594bf92c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-31e6fb11-c309-49c7-9673-910c594bf92c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

