### PR TITLE
Investigate purchase order creation 404 error

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -148,8 +148,8 @@ Route::middleware('auth')->group(function () {
     Route::middleware('role:super_admin,admin,branch_manager')->group(function () {
         Route::get('/purchase-orders', [PurchaseOrderController::class, 'index'])->name('purchase-orders.index');
         Route::get('/purchase-orders/dashboard', [PurchaseOrderController::class, 'dashboard'])->name('purchase-orders.dashboard');
-        Route::get('/purchase-orders/{purchaseOrder}', [PurchaseOrderController::class, 'show'])->name('purchase-orders.show');
-        Route::get('/purchase-orders/{purchaseOrder}/pdf', [PurchaseOrderController::class, 'generatePdf'])->name('purchase-orders.pdf');
+        Route::get('/purchase-orders/{purchaseOrder}', [PurchaseOrderController::class, 'show'])->where('purchaseOrder', '[0-9]+')->name('purchase-orders.show');
+        Route::get('/purchase-orders/{purchaseOrder}/pdf', [PurchaseOrderController::class, 'generatePdf'])->where('purchaseOrder', '[0-9]+')->name('purchase-orders.pdf');
     });
     
     // Purchase Order creation and vendor operations - ONLY for main branch


### PR DESCRIPTION
Add numeric constraints to purchase order routes to prevent "create" from being shadowed.

The dynamic route `/purchase-orders/{purchaseOrder}` was matching the literal string "create", leading to a 404 for the intended `/purchase-orders/create` route due to implicit model binding failing to find a "create" PurchaseOrder. Constraining `purchaseOrder` to numeric IDs resolves this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-be4ea331-0cfc-4a88-af54-8ee87f1575ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be4ea331-0cfc-4a88-af54-8ee87f1575ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

