### PR TITLE
Debug product order form control errors

### DIFF
--- a/resources/views/branch/product-orders/create.blade.php
+++ b/resources/views/branch/product-orders/create.blade.php
@@ -96,7 +96,7 @@
                     <div class="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
                         <div>
                             <label class="form-label">Product *</label>
-                            <select name="items[INDEX][product_id]" class="form-input product-select" required>
+                            <select name="items[INDEX][product_id]" class="form-input product-select">
                                 <option value="">Select Product</option>
                                 @foreach($products as $product)
                                     <option value="{{ $product->id }}" data-category="{{ $product->category }}">
@@ -108,13 +108,13 @@
                         <div>
                             <label class="form-label">Quantity *</label>
                             <input type="number" name="items[INDEX][quantity]" step="0.01" min="0.01" 
-                                   class="form-input quantity-input" required>
+                                   class="form-input quantity-input">
                         </div>
                         <div>
                             <label class="form-label">Reason for Request *</label>
                             <input type="text" name="items[INDEX][reason]" 
                                    class="form-input reason-input" 
-                                   placeholder="e.g., Low stock, customer demand" required>
+                                   placeholder="e.g., Low stock, customer demand">
                         </div>
                         <div>
                             <button type="button" class="remove-item w-full bg-red-50 hover:bg-red-100 text-red-700 font-medium py-2 px-4 rounded-lg transition-colors">
@@ -163,6 +163,16 @@ document.addEventListener('DOMContentLoaded', function() {
         const div = document.createElement('div');
         div.innerHTML = newItem;
         const itemRow = div.firstElementChild;
+        
+        // Add required attributes to the dynamically created elements
+        const productSelect = itemRow.querySelector('.product-select');
+        const quantityInput = itemRow.querySelector('.quantity-input');
+        const reasonInput = itemRow.querySelector('.reason-input');
+        
+        productSelect.setAttribute('required', 'required');
+        quantityInput.setAttribute('required', 'required');
+        reasonInput.setAttribute('required', 'required');
+        
         itemsContainer.appendChild(itemRow);
 
         // Add event listeners

--- a/resources/views/branch/product-orders/edit.blade.php
+++ b/resources/views/branch/product-orders/edit.blade.php
@@ -114,7 +114,7 @@
         <div class="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
             <div>
                 <label class="form-label">Product *</label>
-                <select name="items[INDEX][product_id]" class="form-input product-select" required>
+                <select name="items[INDEX][product_id]" class="form-input product-select">
                     <option value="">Select Product</option>
                     @foreach($products as $product)
                         <option value="{{ $product->id }}">{{ $product->name }} ({{ $product->category }})</option>
@@ -123,11 +123,11 @@
             </div>
             <div>
                 <label class="form-label">Quantity *</label>
-                <input type="number" name="items[INDEX][quantity]" step="0.01" min="0.01" class="form-input quantity-input" required>
+                <input type="number" name="items[INDEX][quantity]" step="0.01" min="0.01" class="form-input quantity-input">
             </div>
             <div>
                 <label class="form-label">Reason *</label>
-                <input type="text" name="items[INDEX][reason]" class="form-input reason-input" required>
+                <input type="text" name="items[INDEX][reason]" class="form-input reason-input">
             </div>
             <div>
                 <button type="button" class="remove-item w-full bg-red-50 hover:bg-red-100 text-red-700 font-medium py-2 px-4 rounded-lg">Remove</button>
@@ -157,6 +157,16 @@ document.addEventListener('DOMContentLoaded', function() {
         const div = document.createElement('div');
         div.innerHTML = newItem;
         const itemRow = div.firstElementChild;
+        
+        // Add required attributes to the dynamically created elements
+        const productSelect = itemRow.querySelector('.product-select');
+        const quantityInput = itemRow.querySelector('.quantity-input');
+        const reasonInput = itemRow.querySelector('.reason-input');
+        
+        productSelect.setAttribute('required', 'required');
+        quantityInput.setAttribute('required', 'required');
+        reasonInput.setAttribute('required', 'required');
+        
         itemsContainer.appendChild(itemRow);
         itemIndex++;
     }

--- a/resources/views/purchase-orders/create.blade.php
+++ b/resources/views/purchase-orders/create.blade.php
@@ -240,19 +240,19 @@
                     <div class="grid grid-cols-1 md:grid-cols-5 gap-4 items-end">
                         <div>
                             <label class="form-label">Product</label>
-                            <select name="items[INDEX][product_id]" class="form-input product-select" required>
+                            <select name="items[INDEX][product_id]" class="form-input product-select">
                                 <option value="">Select Product</option>
                             </select>
                         </div>
                         <div>
                             <label class="form-label">Quantity</label>
                             <input type="number" name="items[INDEX][quantity]" step="0.01" min="0.01"
-                                   class="form-input quantity-input" required>
+                                   class="form-input quantity-input">
                         </div>
                         <div>
                             <label class="form-label">Unit Price (₹)</label>
                             <input type="number" name="items[INDEX][unit_price]" step="0.01" min="0"
-                                   class="form-input price-input" required>
+                                   class="form-input price-input">
                         </div>
                         <div>
                             <label class="form-label">Total Price</label>
@@ -344,12 +344,20 @@ document.addEventListener('DOMContentLoaded', function() {
         const div = document.createElement('div');
         div.innerHTML = newItem;
         const itemRow = div.firstElementChild;
+        
+        // Add required attributes to the dynamically created elements
+        const productSelect = itemRow.querySelector('.product-select');
+        const quantityInput = itemRow.querySelector('.quantity-input');
+        const priceInput = itemRow.querySelector('.price-input');
+        
+        productSelect.setAttribute('required', 'required');
+        quantityInput.setAttribute('required', 'required');
+        priceInput.setAttribute('required', 'required');
+        
         itemsContainer.appendChild(itemRow);
 
         // Add event listeners
         const removeBtn = itemRow.querySelector('.remove-item');
-        const quantityInput = itemRow.querySelector('.quantity-input');
-        const priceInput = itemRow.querySelector('.price-input');
 
         removeBtn.addEventListener('click', function() {
             itemRow.remove();

--- a/resources/views/purchase-orders/edit.blade.php
+++ b/resources/views/purchase-orders/edit.blade.php
@@ -198,19 +198,19 @@
                     <div class="grid grid-cols-1 md:grid-cols-5 gap-4 items-end">
                         <div>
                             <label class="form-label">Product</label>
-                            <select name="items[INDEX][product_id]" class="form-input product-select" required>
+                            <select name="items[INDEX][product_id]" class="form-input product-select">
                                 <option value="">Select Product</option>
                             </select>
                         </div>
                         <div>
                             <label class="form-label">Quantity</label>
                             <input type="number" name="items[INDEX][quantity]" step="0.01" min="0.01"
-                                   class="form-input quantity-input" required>
+                                   class="form-input quantity-input">
                         </div>
                         <div>
                             <label class="form-label">Unit Price (₹)</label>
                             <input type="number" name="items[INDEX][unit_price]" step="0.01" min="0"
-                                   class="form-input price-input" required>
+                                   class="form-input price-input">
                         </div>
                         <div>
                             <label class="form-label">Total Price</label>
@@ -274,6 +274,16 @@ document.addEventListener('DOMContentLoaded', function() {
         const div = document.createElement('div');
         div.innerHTML = newItem;
         const itemRow = div.firstElementChild;
+        
+        // Add required attributes to the dynamically created elements
+        const productSelect = itemRow.querySelector('.product-select');
+        const quantityInput = itemRow.querySelector('.quantity-input');
+        const priceInput = itemRow.querySelector('.price-input');
+        
+        productSelect.setAttribute('required', 'required');
+        quantityInput.setAttribute('required', 'required');
+        priceInput.setAttribute('required', 'required');
+        
         itemsContainer.appendChild(itemRow);
 
         addItemEventListeners(itemRow);


### PR DESCRIPTION
Remove `required` attributes from hidden form templates and add them dynamically via JavaScript to fix "not focusable" validation errors.

The browser was attempting to validate `required` attributes on hidden template elements, causing "An invalid form control... is not focusable" errors. This change ensures `required` attributes are only present on visible, dynamically created form inputs, allowing proper validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c81babb-94fd-4dde-8883-992c09f2796e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c81babb-94fd-4dde-8883-992c09f2796e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

