### PR TITLE
Fix missing vendor id on purchase order creation

### DIFF
--- a/app/Http/Controllers/Day2Day/BranchDashboardController.php
+++ b/app/Http/Controllers/Day2Day/BranchDashboardController.php
@@ -122,11 +122,25 @@ class BranchDashboardController extends Controller
         
         DB::beginTransaction();
         try {
+            // Get or create a system vendor for material receipts
+            $systemVendor = \App\Models\Vendor::firstOrCreate(
+                ['code' => 'SYS002'],
+                [
+                    'name' => 'System - Material Receipts',
+                    'code' => 'SYS002',
+                    'email' => 'system@material-receipts.com',
+                    'phone' => '0000000000',
+                    'address' => 'System Vendor for Material Receipts',
+                    'gst_number' => 'SYSTEM002',
+                    'is_active' => true,
+                ]
+            );
+
             // Create material receipt record (not a purchase order to vendor)
             $materialReceipt = PurchaseOrder::create([
                 'po_number' => $this->generateMaterialReceiptNumber(),
                 'branch_id' => $user->branch_id,
-                'vendor_id' => null, // No direct vendor relationship for sub-branches
+                'vendor_id' => $systemVendor->id, // Use system vendor for material receipts
                 'stock_transfer_id' => $request->stock_transfer_id,
                 'status' => 'received',
                 'order_type' => 'material_receipt',
@@ -614,11 +628,25 @@ class BranchDashboardController extends Controller
                 4, '0', STR_PAD_LEFT
             );
 
+            // Get or create a system vendor for branch requests
+            $systemVendor = \App\Models\Vendor::firstOrCreate(
+                ['code' => 'SYS001'],
+                [
+                    'name' => 'System - Branch Requests',
+                    'code' => 'SYS001',
+                    'email' => 'system@branch-requests.com',
+                    'phone' => '0000000000',
+                    'address' => 'System Vendor for Branch Requests',
+                    'gst_number' => 'SYSTEM001',
+                    'is_active' => true,
+                ]
+            );
+
             // Create purchase request to main branch
             $purchaseRequest = PurchaseOrder::create([
                 'po_number' => $requestNumber,
                 'branch_id' => $user->branch_id,
-                'vendor_id' => null, // No vendor - this is a request to main branch
+                'vendor_id' => $systemVendor->id, // Use system vendor for branch requests
                 'user_id' => $user->id,
                 'status' => 'pending',
                 'order_type' => 'branch_request',

--- a/app/Http/Controllers/Web/BranchProductOrderController.php
+++ b/app/Http/Controllers/Web/BranchProductOrderController.php
@@ -145,10 +145,24 @@ class BranchProductOrderController extends Controller
                 $subtotal += $totalPrice;
             }
 
+            // Get or create a system vendor for branch requests
+            $systemVendor = \App\Models\Vendor::firstOrCreate(
+                ['code' => 'SYS001'],
+                [
+                    'name' => 'System - Branch Requests',
+                    'code' => 'SYS001',
+                    'email' => 'system@branch-requests.com',
+                    'phone' => '0000000000',
+                    'address' => 'System Vendor for Branch Requests',
+                    'gst_number' => 'SYSTEM001',
+                    'is_active' => true,
+                ]
+            );
+
             // Create product order request
             $productOrder = PurchaseOrder::create([
                 'po_number' => $requestNumber,
-                'vendor_id' => null, // No vendor - admin will assign
+                'vendor_id' => $systemVendor->id, // Use system vendor for branch requests
                 'branch_id' => $user->branch_id,
                 'user_id' => $user->id,
                 'status' => 'pending',
@@ -278,8 +292,23 @@ class BranchProductOrderController extends Controller
                 $subtotal += $totalPrice;
             }
 
+            // Get or create a system vendor for branch requests
+            $systemVendor = \App\Models\Vendor::firstOrCreate(
+                ['code' => 'SYS001'],
+                [
+                    'name' => 'System - Branch Requests',
+                    'code' => 'SYS001',
+                    'email' => 'system@branch-requests.com',
+                    'phone' => '0000000000',
+                    'address' => 'System Vendor for Branch Requests',
+                    'gst_number' => 'SYSTEM001',
+                    'is_active' => true,
+                ]
+            );
+
             // Update product order
             $productOrder->update([
+                'vendor_id' => $systemVendor->id, // Ensure system vendor is used
                 'notes' => $request->notes,
                 'expected_delivery_date' => $request->expected_delivery_date,
                 'priority' => $request->priority,

--- a/app/Http/Controllers/Web/PurchaseOrderController.php
+++ b/app/Http/Controllers/Web/PurchaseOrderController.php
@@ -673,10 +673,24 @@ class PurchaseOrderController extends Controller
                 4, '0', STR_PAD_LEFT
             );
 
+            // Get or create a system vendor for branch requests
+            $systemVendor = \App\Models\Vendor::firstOrCreate(
+                ['code' => 'SYS001'],
+                [
+                    'name' => 'System - Branch Requests',
+                    'code' => 'SYS001',
+                    'email' => 'system@branch-requests.com',
+                    'phone' => '0000000000',
+                    'address' => 'System Vendor for Branch Requests',
+                    'gst_number' => 'SYSTEM001',
+                    'is_active' => true,
+                ]
+            );
+
             // Create purchase request (not to vendor, but to main branch)
             $purchaseRequest = PurchaseOrder::create([
                 'po_number' => $requestNumber,
-                'vendor_id' => null, // No vendor - this is a request to main branch
+                'vendor_id' => $systemVendor->id, // Use system vendor for branch requests
                 'branch_id' => $user->branch_id,
                 'user_id' => $user->id,
                 'status' => 'pending',


### PR DESCRIPTION
Assign system vendors to `purchase_orders` of type `branch_request` and `material_receipt` to resolve `vendor_id` cannot be null errors.

The `purchase_orders` table's `vendor_id` column is `NOT NULL`, but `branch_request` and `material_receipt` order types do not have an immediate vendor assigned. This PR introduces placeholder system vendors (SYS001 for branch requests, SYS002 for material receipts) to satisfy the database constraint without requiring schema changes, allowing admins to assign real vendors later.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4373a33-b109-4a59-aa82-c0ffedf8c6c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4373a33-b109-4a59-aa82-c0ffedf8c6c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

