### PR TITLE
Pull changes and migrate database

### DIFF
--- a/database/migrations/2025_09_15_072550_ensure_branch_reference_fields_on_purchase_orders_table.php
+++ b/database/migrations/2025_09_15_072550_ensure_branch_reference_fields_on_purchase_orders_table.php
@@ -39,7 +39,10 @@ return new class extends Migration
             // Add foreign keys only if columns exist and FKs aren't already present
             if (Schema::hasColumn('purchase_orders', 'branch_request_id')) {
                 try {
-                    $table->foreign('branch_request_id')->references('id')->on('purchase_orders')->onDelete('set null');
+                    // Check if branch_requests table exists before creating foreign key
+                    if (Schema::hasTable('branch_requests')) {
+                        $table->foreign('branch_request_id')->references('id')->on('branch_requests')->onDelete('set null');
+                    }
                 } catch (\Throwable $e) {
                     // ignore if FK already exists
                 }
@@ -65,7 +68,11 @@ return new class extends Migration
 
         Schema::table('purchase_orders', function (Blueprint $table) {
             // Best-effort cleanup; ignore errors if constraints are missing
-            try { $table->dropForeign(['branch_request_id']); } catch (\Throwable $e) {}
+            try { 
+                if (Schema::hasTable('branch_requests')) {
+                    $table->dropForeign(['branch_request_id']); 
+                }
+            } catch (\Throwable $e) {}
             try { $table->dropForeign(['ship_to_branch_id']); } catch (\Throwable $e) {}
 
             if (Schema::hasColumn('purchase_orders', 'delivery_address')) {


### PR DESCRIPTION
Correct `purchase_orders` migration to properly reference `branch_requests` table and prevent self-referencing foreign key error.

The original migration `2025_09_15_072550_ensure_branch_reference_fields_on_purchase_orders_table` attempted to create a foreign key `branch_request_id` on `purchase_orders` that referenced `id` on `purchase_orders` itself, leading to a "Duplicate key" error (errno: 121). This fix changes the reference to `branch_requests` and adds a check for the existence of the `branch_requests` table before creating or dropping the foreign key.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee8aac74-075f-4cc7-a871-52244bcf94f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee8aac74-075f-4cc7-a871-52244bcf94f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

