### PR TITLE
Fix stock movement reference type column error

### DIFF
--- a/STOCK_MOVEMENTS_FIX.md
+++ b/STOCK_MOVEMENTS_FIX.md
@@ -1,0 +1,84 @@
+# Stock Movements Database Schema Fix
+
+## Problem
+The application is throwing a database error: `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'reference_type' in 'field list'` when trying to create stock movements during purchase order receiving.
+
+## Root Cause
+The `stock_movements` table is missing the `reference_type` and `reference_id` columns that were supposed to be added by the migration `2025_01_17_000001_enhance_stock_movements_and_add_missing_fields.php`, but this migration hasn't been run yet.
+
+## Solution
+
+### 1. Database Schema Fix
+Run the SQL script `fix_stock_movements_schema.sql` to add the missing columns:
+
+```sql
+-- Add reference_type column if it doesn't exist
+ALTER TABLE stock_movements 
+ADD COLUMN IF NOT EXISTS reference_type VARCHAR(255) NULL 
+AFTER user_id;
+
+-- Add reference_id column if it doesn't exist  
+ALTER TABLE stock_movements 
+ADD COLUMN IF NOT EXISTS reference_id BIGINT UNSIGNED NULL 
+AFTER reference_type;
+
+-- Add movement_type column if it doesn't exist
+ALTER TABLE stock_movements 
+ADD COLUMN IF NOT EXISTS movement_type VARCHAR(255) NULL 
+AFTER type;
+
+-- Add movement_date column if it doesn't exist
+ALTER TABLE stock_movements 
+ADD COLUMN IF NOT EXISTS movement_date TIMESTAMP NULL 
+AFTER reference_id;
+
+-- Update the type enum to include more movement types
+ALTER TABLE stock_movements 
+MODIFY COLUMN type ENUM(
+    'purchase', 'sale', 'adjustment', 'loss', 'return', 
+    'transfer_in', 'transfer_out', 'wastage', 'complimentary'
+) NOT NULL;
+
+-- Add indexes for better performance
+CREATE INDEX IF NOT EXISTS idx_stock_movements_reference ON stock_movements(reference_type, reference_id);
+CREATE INDEX IF NOT EXISTS idx_stock_movements_movement_date ON stock_movements(movement_date);
+```
+
+### 2. Code Fix
+The `PurchaseOrderController.php` has been updated to include all required fields when creating stock movements:
+
+- Added `unit_price` field (using purchase order item's unit price)
+- Added `user_id` field (current authenticated user)
+- Added `movement_date` field (current timestamp)
+
+### 3. Alternative: Run Laravel Migration
+If you have access to PHP/Laravel commands, you can run:
+
+```bash
+php artisan migrate
+```
+
+This will run the pending migration `2025_01_17_000001_enhance_stock_movements_and_add_missing_fields.php` which should add the missing columns.
+
+## Files Modified
+1. `app/Http/Controllers/Web/PurchaseOrderController.php` - Updated StockMovement::create() call
+2. `fix_stock_movements_schema.sql` - SQL script to fix database schema
+
+## Testing
+After applying the fix:
+1. Try to receive a purchase order again
+2. The stock movement should be created successfully
+3. Check that the `stock_movements` table has the new columns populated correctly
+
+## Verification
+You can verify the fix by checking the database schema:
+
+```sql
+DESCRIBE stock_movements;
+```
+
+The table should now include:
+- `reference_type` (VARCHAR)
+- `reference_id` (BIGINT UNSIGNED)
+- `movement_type` (VARCHAR)
+- `movement_date` (TIMESTAMP)

--- a/app/Http/Controllers/Web/PurchaseOrderController.php
+++ b/app/Http/Controllers/Web/PurchaseOrderController.php
@@ -467,8 +467,11 @@ class PurchaseOrderController extends Controller
                         'branch_id' => $targetBranchId,
                         'type' => 'purchase',
                         'quantity' => $receivedQuantity,
+                        'unit_price' => $purchaseOrderItem->unit_price ?? 0,
                         'reference_type' => 'purchase_order',
                         'reference_id' => $purchaseOrder->id,
+                        'user_id' => auth()->id(),
+                        'movement_date' => now(),
                         'notes' => "Received Order from PO: {$purchaseOrder->po_number}",
                     ]);
 

--- a/fix_stock_movements_schema.sql
+++ b/fix_stock_movements_schema.sql
@@ -1,0 +1,34 @@
+-- Fix stock_movements table schema by adding missing columns
+-- This script adds the reference_type and reference_id columns that are missing
+
+-- Add reference_type column if it doesn't exist
+ALTER TABLE stock_movements 
+ADD COLUMN IF NOT EXISTS reference_type VARCHAR(255) NULL 
+AFTER user_id;
+
+-- Add reference_id column if it doesn't exist  
+ALTER TABLE stock_movements 
+ADD COLUMN IF NOT EXISTS reference_id BIGINT UNSIGNED NULL 
+AFTER reference_type;
+
+-- Add movement_type column if it doesn't exist
+ALTER TABLE stock_movements 
+ADD COLUMN IF NOT EXISTS movement_type VARCHAR(255) NULL 
+AFTER type;
+
+-- Add movement_date column if it doesn't exist
+ALTER TABLE stock_movements 
+ADD COLUMN IF NOT EXISTS movement_date TIMESTAMP NULL 
+AFTER reference_id;
+
+-- Update the type enum to include more movement types
+-- First, we need to modify the existing enum
+ALTER TABLE stock_movements 
+MODIFY COLUMN type ENUM(
+    'purchase', 'sale', 'adjustment', 'loss', 'return', 
+    'transfer_in', 'transfer_out', 'wastage', 'complimentary'
+) NOT NULL;
+
+-- Add indexes for better performance
+CREATE INDEX IF NOT EXISTS idx_stock_movements_reference ON stock_movements(reference_type, reference_id);
+CREATE INDEX IF NOT EXISTS idx_stock_movements_movement_date ON stock_movements(movement_date);


### PR DESCRIPTION
Fix `Column not found` error in `stock_movements` by adding missing schema columns and populating required fields during stock movement creation.

The `stock_movements` table lacked `reference_type` and `reference_id` columns, which were expected by the code. Additionally, the `StockMovement::create()` method was missing `user_id`, `unit_price`, and `movement_date` fields, which are necessary for a complete stock movement record. This PR addresses both the database schema discrepancy and the incomplete data insertion.

---
<a href="https://cursor.com/background-agent?bcId=bc-7fdb53e9-c660-4ad0-8b80-cde4fa1b391b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7fdb53e9-c660-4ad0-8b80-cde4fa1b391b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

