### PR TITLE
Fix stock movement column error

### DIFF
--- a/database/migrations/2025_09_15_072550_ensure_branch_reference_fields_on_purchase_orders_table.php
+++ b/database/migrations/2025_09_15_072550_ensure_branch_reference_fields_on_purchase_orders_table.php
@@ -36,16 +36,8 @@ return new class extends Migration
             }
         });
 
-        // Check if foreign keys already exist before trying to create them
-        $existingForeignKeys = DB::select("
-            SELECT CONSTRAINT_NAME 
-            FROM information_schema.KEY_COLUMN_USAGE 
-            WHERE TABLE_SCHEMA = DATABASE() 
-            AND TABLE_NAME = 'purchase_orders' 
-            AND CONSTRAINT_NAME LIKE '%_foreign'
-        ");
-        
-        $existingConstraintNames = array_column($existingForeignKeys, 'CONSTRAINT_NAME');
+        // For SQLite, we'll skip the foreign key check and just try to create them
+        $existingConstraintNames = [];
         
         Schema::table('purchase_orders', function (Blueprint $table) use ($existingConstraintNames) {
             // Add foreign keys only if columns exist and FKs aren't already present


### PR DESCRIPTION
Fixes `Column not found` error for `reference_type` in `stock_movements` by ensuring migrations run correctly on SQLite.

The error occurred because the `stock_movements` table was missing the `reference_type` column. The migration intended to add this column failed when running on SQLite due to MySQL-specific `information_schema` queries. This PR modifies the problematic migration to be compatible with SQLite, allowing all migrations to run successfully and resolve the missing column issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-50e7832c-5275-4b3e-90d6-cc69e4ebca10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-50e7832c-5275-4b3e-90d6-cc69e4ebca10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

