### PR TITLE
Fix purchase orders not showing on entry page

### DIFF
--- a/database/seeders/BasicDataSeeder.php
+++ b/database/seeders/BasicDataSeeder.php
@@ -526,7 +526,8 @@ class BasicDataSeeder extends Seeder
                 'vendor_id' => 1,
                 'branch_id' => 1,
                 'user_id' => 2, // branch manager
-                'status' => 'sent',
+                'status' => 'approved',
+                'order_type' => 'branch_request',
                 'payment_terms' => '15_days',
                 'subtotal' => 5000.00,
                 'tax_amount' => 0.00,
@@ -535,15 +536,17 @@ class BasicDataSeeder extends Seeder
                 'notes' => 'Fresh produce order',
                 'expected_delivery_date' => now()->addDays(2),
                 'actual_delivery_date' => null,
+                'received_at' => null,
                 'created_at' => now()->subDays(5),
                 'updated_at' => now()->subDays(5),
             ],
             [
                 'po_number' => 'PO002',
                 'vendor_id' => 2,
-                'branch_id' => 2,
+                'branch_id' => 1,
                 'user_id' => 2, // branch manager
-                'status' => 'confirmed',
+                'status' => 'fulfilled',
+                'order_type' => 'branch_request',
                 'payment_terms' => '7_days',
                 'subtotal' => 3500.00,
                 'tax_amount' => 0.00,
@@ -552,12 +555,131 @@ class BasicDataSeeder extends Seeder
                 'notes' => 'Mixed vegetables order',
                 'expected_delivery_date' => now()->addDays(1),
                 'actual_delivery_date' => null,
+                'received_at' => null,
                 'created_at' => now()->subDays(3),
                 'updated_at' => now()->subDays(3),
+            ],
+            [
+                'po_number' => 'PO003',
+                'vendor_id' => 1,
+                'branch_id' => 1,
+                'user_id' => 2, // branch manager
+                'status' => 'approved',
+                'order_type' => 'branch_request',
+                'payment_terms' => '10_days',
+                'subtotal' => 2500.00,
+                'tax_amount' => 0.00,
+                'transport_cost' => 100.00,
+                'total_amount' => 2600.00,
+                'notes' => 'Organic vegetables order',
+                'expected_delivery_date' => now()->addDays(3),
+                'actual_delivery_date' => null,
+                'received_at' => null,
+                'created_at' => now()->subDays(2),
+                'updated_at' => now()->subDays(2),
             ],
         ];
 
         DB::table('purchase_orders')->insert($purchaseOrders);
+
+        // Create purchase order items
+        $purchaseOrderItems = [
+            // PO001 items
+            [
+                'purchase_order_id' => 1,
+                'product_id' => 1, // Apples
+                'quantity' => 20.0,
+                'unit_price' => 120.00,
+                'total_price' => 2400.00,
+                'fulfilled_quantity' => 20.0,
+                'created_at' => now()->subDays(5),
+                'updated_at' => now()->subDays(5),
+            ],
+            [
+                'purchase_order_id' => 1,
+                'product_id' => 3, // Spinach
+                'quantity' => 15.0,
+                'unit_price' => 30.00,
+                'total_price' => 450.00,
+                'fulfilled_quantity' => 15.0,
+                'created_at' => now()->subDays(5),
+                'updated_at' => now()->subDays(5),
+            ],
+            [
+                'purchase_order_id' => 1,
+                'product_id' => 5, // Carrots
+                'quantity' => 25.0,
+                'unit_price' => 35.00,
+                'total_price' => 875.00,
+                'fulfilled_quantity' => 25.0,
+                'created_at' => now()->subDays(5),
+                'updated_at' => now()->subDays(5),
+            ],
+            // PO002 items
+            [
+                'purchase_order_id' => 2,
+                'product_id' => 2, // Tomatoes
+                'quantity' => 30.0,
+                'unit_price' => 40.00,
+                'total_price' => 1200.00,
+                'fulfilled_quantity' => 30.0,
+                'created_at' => now()->subDays(3),
+                'updated_at' => now()->subDays(3),
+            ],
+            [
+                'purchase_order_id' => 2,
+                'product_id' => 4, // Oranges
+                'quantity' => 20.0,
+                'unit_price' => 80.00,
+                'total_price' => 1600.00,
+                'fulfilled_quantity' => 20.0,
+                'created_at' => now()->subDays(3),
+                'updated_at' => now()->subDays(3),
+            ],
+            [
+                'purchase_order_id' => 2,
+                'product_id' => 1, // Apples
+                'quantity' => 10.0,
+                'unit_price' => 120.00,
+                'total_price' => 1200.00,
+                'fulfilled_quantity' => 10.0,
+                'created_at' => now()->subDays(3),
+                'updated_at' => now()->subDays(3),
+            ],
+            // PO003 items
+            [
+                'purchase_order_id' => 3,
+                'product_id' => 3, // Spinach
+                'quantity' => 20.0,
+                'unit_price' => 30.00,
+                'total_price' => 600.00,
+                'fulfilled_quantity' => 20.0,
+                'created_at' => now()->subDays(2),
+                'updated_at' => now()->subDays(2),
+            ],
+            [
+                'purchase_order_id' => 3,
+                'product_id' => 5, // Carrots
+                'quantity' => 15.0,
+                'unit_price' => 35.00,
+                'total_price' => 525.00,
+                'fulfilled_quantity' => 15.0,
+                'created_at' => now()->subDays(2),
+                'updated_at' => now()->subDays(2),
+            ],
+            [
+                'purchase_order_id' => 3,
+                'product_id' => 2, // Tomatoes
+                'quantity' => 25.0,
+                'unit_price' => 40.00,
+                'total_price' => 1000.00,
+                'fulfilled_quantity' => 25.0,
+                'created_at' => now()->subDays(2),
+                'updated_at' => now()->subDays(2),
+            ],
+        ];
+
+        DB::table('purchase_order_items')->insert($purchaseOrderItems);
 
         // Create expense categories
         $expenseCategories = [

--- a/debug_purchase_entries.php
+++ b/debug_purchase_entries.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Debug Purchase Entries Script
+ * 
+ * This script helps debug why purchase orders are not showing on the Create Purchase Entry page.
+ * It checks the user, roles, and purchase order data to identify the issue.
+ */
+
+require_once 'vendor/autoload.php';
+
+// Bootstrap Laravel
+$app = require_once 'bootstrap/app.php';
+$app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+
+use Illuminate\Support\Facades\DB;
+use App\Models\PurchaseOrder;
+use App\Models\User;
+use App\Models\Role;
+
+echo "=== DEBUGGING PURCHASE ENTRIES ISSUE ===\n\n";
+
+try {
+    // Check users and their roles
+    echo "1. Checking users and roles...\n";
+    $users = User::with('roles')->get();
+    foreach ($users as $user) {
+        echo "User: {$user->name} (ID: {$user->id}, Branch ID: {$user->branch_id})\n";
+        foreach ($user->roles as $role) {
+            echo "  - Role: {$role->name}\n";
+        }
+    }
+    echo "\n";
+
+    // Check branch managers specifically
+    echo "2. Checking branch managers...\n";
+    $branchManagers = User::whereHas('roles', function($query) {
+        $query->where('name', 'branch_manager');
+    })->get();
+    
+    foreach ($branchManagers as $manager) {
+        echo "Branch Manager: {$manager->name} (ID: {$manager->id}, Branch ID: {$manager->branch_id})\n";
+    }
+    echo "\n";
+
+    // Check all purchase orders
+    echo "3. Checking all purchase orders...\n";
+    $allOrders = PurchaseOrder::with(['vendor', 'purchaseOrderItems'])->get();
+    echo "Total purchase orders: " . $allOrders->count() . "\n";
+    
+    foreach ($allOrders as $order) {
+        echo "PO: {$order->po_number} (ID: {$order->id}, Branch: {$order->branch_id}, Status: {$order->status}, Order Type: {$order->order_type}, Received: " . ($order->received_at ? 'Yes' : 'No') . ")\n";
+    }
+    echo "\n";
+
+    // Check purchase orders for branch 1
+    echo "4. Checking purchase orders for branch 1...\n";
+    $branch1Orders = PurchaseOrder::where('branch_id', 1)->get();
+    echo "Branch 1 orders: " . $branch1Orders->count() . "\n";
+    
+    foreach ($branch1Orders as $order) {
+        echo "PO: {$order->po_number} (Status: {$order->status}, Order Type: {$order->order_type}, Received: " . ($order->received_at ? 'Yes' : 'No') . ")\n";
+    }
+    echo "\n";
+
+    // Check the exact query from the controller
+    echo "5. Testing the exact controller query...\n";
+    $user = User::where('branch_id', 1)->whereHas('roles', function($query) {
+        $query->where('name', 'branch_manager');
+    })->first();
+    
+    if ($user) {
+        echo "Found branch manager user: {$user->name} (Branch ID: {$user->branch_id})\n";
+        
+        $availablePurchaseOrders = PurchaseOrder::with(['vendor', 'purchaseOrderItems.product'])
+            ->where('branch_id', $user->branch_id)
+            ->where('order_type', 'branch_request')
+            ->whereIn('status', ['approved', 'fulfilled'])
+            ->whereNull('received_at')
+            ->orderBy('created_at', 'desc')
+            ->get();
+            
+        echo "Available purchase orders for this user: " . $availablePurchaseOrders->count() . "\n";
+        
+        foreach ($availablePurchaseOrders as $order) {
+            echo "  - PO: {$order->po_number} (Status: {$order->status}, Vendor: {$order->vendor->name}, Items: {$order->purchaseOrderItems->count()})\n";
+        }
+    } else {
+        echo "No branch manager found for branch 1!\n";
+    }
+    echo "\n";
+
+    // Check what's missing
+    echo "6. Analyzing what's missing...\n";
+    
+    $branch1Orders = PurchaseOrder::where('branch_id', 1)->get();
+    $hasBranchRequest = $branch1Orders->where('order_type', 'branch_request')->count();
+    $hasApprovedOrFulfilled = $branch1Orders->whereIn('status', ['approved', 'fulfilled'])->count();
+    $hasNotReceived = $branch1Orders->whereNull('received_at')->count();
+    
+    echo "Branch 1 orders with order_type='branch_request': {$hasBranchRequest}\n";
+    echo "Branch 1 orders with status in ['approved', 'fulfilled']: {$hasApprovedOrFulfilled}\n";
+    echo "Branch 1 orders with received_at IS NULL: {$hasNotReceived}\n";
+    
+    if ($hasBranchRequest == 0) {
+        echo "ISSUE: No orders have order_type='branch_request'\n";
+    }
+    if ($hasApprovedOrFulfilled == 0) {
+        echo "ISSUE: No orders have status 'approved' or 'fulfilled'\n";
+    }
+    if ($hasNotReceived == 0) {
+        echo "ISSUE: All orders have received_at set\n";
+    }
+    
+    echo "\n=== DEBUG COMPLETE ===\n";
+
+} catch (Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+    echo "Stack trace: " . $e->getTraceAsString() . "\n";
+    exit(1);
+}

--- a/fix_purchase_orders.php
+++ b/fix_purchase_orders.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Fix Purchase Orders Script
+ * 
+ * This script fixes the purchase orders data to show up on the Create Purchase Entry page.
+ * It updates existing purchase orders and creates test data with the correct status and order_type.
+ */
+
+require_once 'vendor/autoload.php';
+
+// Bootstrap Laravel
+$app = require_once 'bootstrap/app.php';
+$app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+
+use Illuminate\Support\Facades\DB;
+use App\Models\PurchaseOrder;
+use App\Models\PurchaseOrderItem;
+
+echo "Starting purchase orders fix...\n";
+
+try {
+    // Start transaction
+    DB::beginTransaction();
+
+    // Update existing purchase orders
+    echo "Updating existing purchase orders...\n";
+    
+    $existingOrders = PurchaseOrder::whereIn('id', [1, 2])->get();
+    
+    foreach ($existingOrders as $order) {
+        $order->update([
+            'order_type' => 'branch_request',
+            'status' => $order->id == 1 ? 'approved' : 'fulfilled',
+            'received_at' => null,
+        ]);
+        echo "Updated PO {$order->po_number} to status: {$order->status}\n";
+    }
+
+    // Create additional test purchase order
+    echo "Creating additional test purchase order...\n";
+    
+    $newOrder = PurchaseOrder::create([
+        'po_number' => 'PO003',
+        'vendor_id' => 1,
+        'branch_id' => 1,
+        'user_id' => 2,
+        'status' => 'approved',
+        'order_type' => 'branch_request',
+        'payment_terms' => '10_days',
+        'subtotal' => 2500.00,
+        'tax_amount' => 0.00,
+        'transport_cost' => 100.00,
+        'total_amount' => 2600.00,
+        'notes' => 'Organic vegetables order',
+        'expected_delivery_date' => now()->addDays(3),
+        'actual_delivery_date' => null,
+        'received_at' => null,
+        'created_at' => now()->subDays(2),
+        'updated_at' => now()->subDays(2),
+    ]);
+
+    echo "Created PO {$newOrder->po_number}\n";
+
+    // Create purchase order items for all orders
+    echo "Creating purchase order items...\n";
+    
+    $orderItems = [
+        // PO001 items
+        ['purchase_order_id' => 1, 'product_id' => 1, 'quantity' => 20.0, 'unit_price' => 120.00, 'total_price' => 2400.00, 'fulfilled_quantity' => 20.0],
+        ['purchase_order_id' => 1, 'product_id' => 3, 'quantity' => 15.0, 'unit_price' => 30.00, 'total_price' => 450.00, 'fulfilled_quantity' => 15.0],
+        ['purchase_order_id' => 1, 'product_id' => 5, 'quantity' => 25.0, 'unit_price' => 35.00, 'total_price' => 875.00, 'fulfilled_quantity' => 25.0],
+        
+        // PO002 items
+        ['purchase_order_id' => 2, 'product_id' => 2, 'quantity' => 30.0, 'unit_price' => 40.00, 'total_price' => 1200.00, 'fulfilled_quantity' => 30.0],
+        ['purchase_order_id' => 2, 'product_id' => 4, 'quantity' => 20.0, 'unit_price' => 80.00, 'total_price' => 1600.00, 'fulfilled_quantity' => 20.0],
+        ['purchase_order_id' => 2, 'product_id' => 1, 'quantity' => 10.0, 'unit_price' => 120.00, 'total_price' => 1200.00, 'fulfilled_quantity' => 10.0],
+        
+        // PO003 items
+        ['purchase_order_id' => 3, 'product_id' => 3, 'quantity' => 20.0, 'unit_price' => 30.00, 'total_price' => 600.00, 'fulfilled_quantity' => 20.0],
+        ['purchase_order_id' => 3, 'product_id' => 5, 'quantity' => 15.0, 'unit_price' => 35.00, 'total_price' => 525.00, 'fulfilled_quantity' => 15.0],
+        ['purchase_order_id' => 3, 'product_id' => 2, 'quantity' => 25.0, 'unit_price' => 40.00, 'total_price' => 1000.00, 'fulfilled_quantity' => 25.0],
+    ];
+
+    foreach ($orderItems as $item) {
+        $item['created_at'] = now()->subDays($item['purchase_order_id'] == 1 ? 5 : ($item['purchase_order_id'] == 2 ? 3 : 2));
+        $item['updated_at'] = $item['created_at'];
+        
+        PurchaseOrderItem::create($item);
+    }
+
+    echo "Created " . count($orderItems) . " purchase order items\n";
+
+    // Commit transaction
+    DB::commit();
+
+    // Verify the results
+    echo "\nVerifying results...\n";
+    
+    $availableOrders = PurchaseOrder::with(['vendor', 'purchaseOrderItems.product'])
+        ->where('branch_id', 1)
+        ->where('order_type', 'branch_request')
+        ->whereIn('status', ['approved', 'fulfilled'])
+        ->whereNull('received_at')
+        ->orderBy('created_at', 'desc')
+        ->get();
+
+    echo "Found " . $availableOrders->count() . " available purchase orders:\n";
+    
+    foreach ($availableOrders as $order) {
+        echo "- PO {$order->po_number} ({$order->status}) - {$order->vendor->name} - {$order->purchaseOrderItems->count()} items - ₹{$order->total_amount}\n";
+    }
+
+    echo "\nPurchase orders fix completed successfully!\n";
+    echo "The Create Purchase Entry page should now show the available purchase orders.\n";
+
+} catch (Exception $e) {
+    DB::rollback();
+    echo "Error: " . $e->getMessage() . "\n";
+    exit(1);
+}

--- a/fix_purchase_orders.sql
+++ b/fix_purchase_orders.sql
@@ -1,0 +1,65 @@
+-- Fix purchase orders to show up on Create Purchase Entry page
+-- This script updates existing purchase orders to have the correct status and order_type
+
+-- Update existing purchase orders to have the correct order_type and status
+UPDATE purchase_orders 
+SET 
+    order_type = 'branch_request',
+    status = CASE 
+        WHEN id = 1 THEN 'approved'
+        WHEN id = 2 THEN 'fulfilled'
+        ELSE 'approved'
+    END,
+    received_at = NULL
+WHERE id IN (1, 2);
+
+-- Insert additional purchase order for testing
+INSERT INTO purchase_orders (
+    po_number, vendor_id, branch_id, user_id, status, order_type, 
+    payment_terms, subtotal, tax_amount, transport_cost, total_amount, 
+    notes, expected_delivery_date, actual_delivery_date, received_at, 
+    created_at, updated_at
+) VALUES (
+    'PO003', 1, 1, 2, 'approved', 'branch_request', 
+    '10_days', 2500.00, 0.00, 100.00, 2600.00, 
+    'Organic vegetables order', DATE_ADD(NOW(), INTERVAL 3 DAY), NULL, NULL, 
+    DATE_SUB(NOW(), INTERVAL 2 DAY), DATE_SUB(NOW(), INTERVAL 2 DAY)
+);
+
+-- Insert purchase order items for the existing orders
+INSERT INTO purchase_order_items (
+    purchase_order_id, product_id, quantity, unit_price, total_price, 
+    fulfilled_quantity, created_at, updated_at
+) VALUES 
+-- PO001 items
+(1, 1, 20.0, 120.00, 2400.00, 20.0, DATE_SUB(NOW(), INTERVAL 5 DAY), DATE_SUB(NOW(), INTERVAL 5 DAY)),
+(1, 3, 15.0, 30.00, 450.00, 15.0, DATE_SUB(NOW(), INTERVAL 5 DAY), DATE_SUB(NOW(), INTERVAL 5 DAY)),
+(1, 5, 25.0, 35.00, 875.00, 25.0, DATE_SUB(NOW(), INTERVAL 5 DAY), DATE_SUB(NOW(), INTERVAL 5 DAY)),
+-- PO002 items  
+(2, 2, 30.0, 40.00, 1200.00, 30.0, DATE_SUB(NOW(), INTERVAL 3 DAY), DATE_SUB(NOW(), INTERVAL 3 DAY)),
+(2, 4, 20.0, 80.00, 1600.00, 20.0, DATE_SUB(NOW(), INTERVAL 3 DAY), DATE_SUB(NOW(), INTERVAL 3 DAY)),
+(2, 1, 10.0, 120.00, 1200.00, 10.0, DATE_SUB(NOW(), INTERVAL 3 DAY), DATE_SUB(NOW(), INTERVAL 3 DAY)),
+-- PO003 items
+(3, 3, 20.0, 30.00, 600.00, 20.0, DATE_SUB(NOW(), INTERVAL 2 DAY), DATE_SUB(NOW(), INTERVAL 2 DAY)),
+(3, 5, 15.0, 35.00, 525.00, 15.0, DATE_SUB(NOW(), INTERVAL 2 DAY), DATE_SUB(NOW(), INTERVAL 2 DAY)),
+(3, 2, 25.0, 40.00, 1000.00, 25.0, DATE_SUB(NOW(), INTERVAL 2 DAY), DATE_SUB(NOW(), INTERVAL 2 DAY));
+
+-- Verify the data
+SELECT 
+    po.id,
+    po.po_number,
+    po.status,
+    po.order_type,
+    po.branch_id,
+    po.received_at,
+    v.name as vendor_name,
+    COUNT(poi.id) as items_count
+FROM purchase_orders po
+LEFT JOIN vendors v ON po.vendor_id = v.id
+LEFT JOIN purchase_order_items poi ON po.id = poi.purchase_order_id
+WHERE po.branch_id = 1 
+    AND po.order_type = 'branch_request'
+    AND po.status IN ('approved', 'fulfilled')
+    AND po.received_at IS NULL
+GROUP BY po.id, po.po_number, po.status, po.order_type, po.branch_id, po.received_at, v.name
+ORDER BY po.created_at DESC;

--- a/purchase_orders_fix_guide.html
+++ b/purchase_orders_fix_guide.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Purchase Orders Fix Guide</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+        }
+        .issue {
+            background-color: #fef2f2;
+            border: 1px solid #fecaca;
+            border-radius: 8px;
+            padding: 20px;
+            margin: 20px 0;
+        }
+        .solution {
+            background-color: #f0fdf4;
+            border: 1px solid #bbf7d0;
+            border-radius: 8px;
+            padding: 20px;
+            margin: 20px 0;
+        }
+        .code {
+            background-color: #f3f4f6;
+            border: 1px solid #d1d5db;
+            border-radius: 4px;
+            padding: 15px;
+            font-family: 'Courier New', monospace;
+            overflow-x: auto;
+        }
+        .step {
+            background-color: #eff6ff;
+            border-left: 4px solid #3b82f6;
+            padding: 15px;
+            margin: 10px 0;
+        }
+        .warning {
+            background-color: #fffbeb;
+            border: 1px solid #fed7aa;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        h1, h2, h3 {
+            color: #1f2937;
+        }
+        .highlight {
+            background-color: #fef3c7;
+            padding: 2px 4px;
+            border-radius: 3px;
+        }
+    </style>
+</head>
+<body>
+    <h1>🔧 Purchase Orders Not Showing - Fix Guide</h1>
+    
+    <div class="issue">
+        <h2>🚨 Issue Identified</h2>
+        <p>The "Create Purchase Entry" page is showing "No Purchase Orders Available" because the existing purchase orders in the database don't match the query conditions in the controller.</p>
+        
+        <h3>Root Causes:</h3>
+        <ul>
+            <li><strong>Missing <span class="highlight">order_type</span> field:</strong> The seeder data doesn't include <code>order_type = 'branch_request'</code></li>
+            <li><strong>Wrong status values:</strong> Seeder creates orders with status <code>'sent'</code> and <code>'confirmed'</code>, but controller looks for <code>'approved'</code> and <code>'fulfilled'</code></li>
+            <li><strong>Missing <span class="highlight">received_at</span> field:</strong> Controller filters for <code>whereNull('received_at')</code> but this field isn't set in seeder</li>
+        </ul>
+    </div>
+
+    <div class="solution">
+        <h2>✅ Solution</h2>
+        <p>I've created several files to fix this issue. Choose the method that works best for your environment:</p>
+        
+        <div class="step">
+            <h3>Method 1: SQL Script (Recommended if you have database access)</h3>
+            <p>Run the SQL script I created to fix the existing data:</p>
+            <div class="code">
+                -- Run this SQL script in your database
+                mysql -u your_username -p your_database_name < fix_purchase_orders.sql
+            </div>
+            <p>This will:</p>
+            <ul>
+                <li>Update existing purchase orders with correct <code>order_type</code> and <code>status</code></li>
+                <li>Create additional test purchase orders</li>
+                <li>Add purchase order items for all orders</li>
+            </ul>
+        </div>
+
+        <div class="step">
+            <h3>Method 2: PHP Script (If PHP is available)</h3>
+            <p>Run the PHP script I created:</p>
+            <div class="code">
+                php fix_purchase_orders.php
+            </div>
+            <p>This will do the same as the SQL script but using Laravel's ORM.</p>
+        </div>
+
+        <div class="step">
+            <h3>Method 3: Debug Script (To understand the issue better)</h3>
+            <p>Run the debug script to see what's wrong:</p>
+            <div class="code">
+                php debug_purchase_entries.php
+            </div>
+            <p>This will show you exactly what data exists and what's missing.</p>
+        </div>
+    </div>
+
+    <div class="warning">
+        <h3>⚠️ Important Notes</h3>
+        <ul>
+            <li>Make sure you have a backup of your database before running any scripts</li>
+            <li>The branch manager user should have <code>branch_id = 1</code> to see the test data</li>
+            <li>After running the fix, refresh the "Create Purchase Entry" page to see the results</li>
+        </ul>
+    </div>
+
+    <h2>🔍 What the Fix Does</h2>
+    <p>The fix addresses these specific issues:</p>
+    
+    <div class="code">
+        <strong>Before (Seeder Data):</strong>
+        - order_type: NULL (missing)
+        - status: 'sent', 'confirmed' 
+        - received_at: NULL (but not explicitly set)
+        
+        <strong>After (Fixed Data):</strong>
+        - order_type: 'branch_request' ✅
+        - status: 'approved', 'fulfilled' ✅  
+        - received_at: NULL (explicitly set) ✅
+    </div>
+
+    <h2>🎯 Expected Result</h2>
+    <p>After running the fix, the "Create Purchase Entry" page should show:</p>
+    <ul>
+        <li><strong>PO001</strong> - Fresh produce order (Approved) - ₹5,000.00</li>
+        <li><strong>PO002</strong> - Mixed vegetables order (Fulfilled) - ₹3,500.00</li>
+        <li><strong>PO003</strong> - Organic vegetables order (Approved) - ₹2,600.00</li>
+    </ul>
+
+    <h2>📁 Files Created</h2>
+    <ul>
+        <li><code>fix_purchase_orders.sql</code> - SQL script to fix the data</li>
+        <li><code>fix_purchase_orders.php</code> - PHP script to fix the data</li>
+        <li><code>debug_purchase_entries.php</code> - Debug script to analyze the issue</li>
+        <li><code>database/seeders/BasicDataSeeder.php</code> - Updated with correct test data</li>
+    </ul>
+
+    <div class="solution">
+        <h2>🚀 Quick Test</h2>
+        <p>To quickly test if the fix worked, you can manually run this query in your database:</p>
+        <div class="code">
+            SELECT po.po_number, po.status, po.order_type, v.name as vendor_name, 
+                   COUNT(poi.id) as items_count, po.total_amount
+            FROM purchase_orders po
+            LEFT JOIN vendors v ON po.vendor_id = v.id  
+            LEFT JOIN purchase_order_items poi ON po.id = poi.purchase_order_id
+            WHERE po.branch_id = 1 
+                AND po.order_type = 'branch_request'
+                AND po.status IN ('approved', 'fulfilled')
+                AND po.received_at IS NULL
+            GROUP BY po.id
+            ORDER BY po.created_at DESC;
+        </div>
+        <p>This should return 3 purchase orders that will show up on the Create Purchase Entry page.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Correct purchase order seeder data to resolve purchase orders not appearing on the 'Create Purchase Entry' page.

The 'Create Purchase Entry' page failed to display purchase orders because the seeded data did not meet the controller's filtering criteria for `order_type` ('branch_request'), `status` ('approved' or 'fulfilled'), and `received_at` (expected NULL). This change updates the `BasicDataSeeder` to create compliant test data and provides utility scripts for fixing existing database entries.

---
<a href="https://cursor.com/background-agent?bcId=bc-9eae12a8-247d-485b-8fa0-07a44975a816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9eae12a8-247d-485b-8fa0-07a44975a816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

