### PR TITLE
Fix undefined array key for approved orders

### DIFF
--- a/app/Http/Controllers/Web/BranchPurchaseEntryController.php
+++ b/app/Http/Controllers/Web/BranchPurchaseEntryController.php
@@ -72,10 +72,10 @@ class BranchPurchaseEntryController extends Controller
         $purchaseEntries = $query->latest()->paginate(15);
 
         $stats = [
-            'sent_orders' => PurchaseOrder::where('branch_id', $user->branch_id)
+            'approved_orders' => PurchaseOrder::where('branch_id', $user->branch_id)
                 ->where('order_type', 'branch_request')
                 ->where('status', 'sent')->count(),
-            'confirmed_orders' => PurchaseOrder::where('branch_id', $user->branch_id)
+            'fulfilled_orders' => PurchaseOrder::where('branch_id', $user->branch_id)
                 ->where('order_type', 'branch_request')
                 ->where('status', 'confirmed')->count(),
             'pending_receipt' => PurchaseOrder::where('branch_id', $user->branch_id)


### PR DESCRIPTION
Rename purchase order stats keys in controller to match Blade template expectations and resolve 'Undefined array key' error.

---
<a href="https://cursor.com/background-agent?bcId=bc-71b7a04c-b41e-4040-88cd-dca9bbded922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-71b7a04c-b41e-4040-88cd-dca9bbded922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

