### PR TITLE
Add purchase entries shortcut to admin sidebar

### DIFF
--- a/app/Http/Controllers/Web/AdminController.php
+++ b/app/Http/Controllers/Web/AdminController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Models\Role;
 use App\Models\Branch;
+use App\Models\PurchaseEntry;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rule;
@@ -232,5 +233,17 @@ class AdminController extends Controller
             ->get();
 
         return view('admin.branches.performance', compact('branches'));
+    }
+
+    /**
+     * Display all purchase entries across all branches
+     */
+    public function purchaseEntries()
+    {
+        $purchaseEntries = PurchaseEntry::with(['branch', 'purchaseOrder', 'items.product'])
+            ->orderBy('created_at', 'desc')
+            ->paginate(20);
+
+        return view('admin.purchase-entries.index', compact('purchaseEntries'));
     }
 }

--- a/resources/views/admin/purchase-entries/index.blade.php
+++ b/resources/views/admin/purchase-entries/index.blade.php
@@ -1,0 +1,215 @@
+@extends('layouts.super-admin')
+
+@section('title', 'Purchase Entries Management')
+
+@section('content')
+<div class="p-6">
+    <!-- Page Header -->
+    <div class="mb-8">
+        <div class="flex items-center justify-between">
+            <div>
+                <h1 class="text-3xl font-bold text-gray-900">Purchase Entries Management</h1>
+                <p class="text-gray-600 mt-1">View and manage all purchase entries across all branches.</p>
+            </div>
+            <div class="flex items-center space-x-3">
+                <button onclick="refreshData()" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg font-medium transition-colors">
+                    <i class="fas fa-sync-alt mr-2"></i>
+                    Refresh
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Success/Error Messages -->
+    @if(session('success'))
+        <div class="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg mb-6">
+            {{ session('success') }}
+        </div>
+    @endif
+
+    @if(session('error'))
+        <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-6">
+            {{ session('error') }}
+        </div>
+    @endif
+
+    <!-- Purchase Entries Stats -->
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+        <div class="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
+            <div class="flex items-center">
+                <div class="bg-blue-100 p-3 rounded-lg">
+                    <i class="fas fa-receipt text-blue-600 text-xl"></i>
+                </div>
+                <div class="ml-4">
+                    <p class="text-sm font-medium text-gray-600">Total Entries</p>
+                    <p class="text-2xl font-bold text-gray-900">{{ $purchaseEntries->total() }}</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
+            <div class="flex items-center">
+                <div class="bg-green-100 p-3 rounded-lg">
+                    <i class="fas fa-check-circle text-green-600 text-xl"></i>
+                </div>
+                <div class="ml-4">
+                    <p class="text-sm font-medium text-gray-600">Completed</p>
+                    <p class="text-2xl font-bold text-gray-900">{{ $purchaseEntries->where('status', 'completed')->count() }}</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
+            <div class="flex items-center">
+                <div class="bg-yellow-100 p-3 rounded-lg">
+                    <i class="fas fa-clock text-yellow-600 text-xl"></i>
+                </div>
+                <div class="ml-4">
+                    <p class="text-sm font-medium text-gray-600">Pending</p>
+                    <p class="text-2xl font-bold text-gray-900">{{ $purchaseEntries->where('status', 'pending')->count() }}</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
+            <div class="flex items-center">
+                <div class="bg-red-100 p-3 rounded-lg">
+                    <i class="fas fa-exclamation-triangle text-red-600 text-xl"></i>
+                </div>
+                <div class="ml-4">
+                    <p class="text-sm font-medium text-gray-600">Issues</p>
+                    <p class="text-2xl font-bold text-gray-900">{{ $purchaseEntries->where('status', 'discrepancy')->count() }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Purchase Entries Table -->
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200">
+        <div class="px-6 py-4 border-b border-gray-200">
+            <h3 class="text-lg font-semibold text-gray-900">All Purchase Entries</h3>
+        </div>
+        
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            Entry ID
+                        </th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            Branch
+                        </th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            Purchase Order
+                        </th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            Status
+                        </th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            Total Amount
+                        </th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            Created Date
+                        </th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            Actions
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                    @forelse($purchaseEntries as $entry)
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <div class="text-sm font-medium text-gray-900">
+                                #{{ $entry->id }}
+                            </div>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <div class="text-sm text-gray-900">{{ $entry->branch->name ?? 'N/A' }}</div>
+                            <div class="text-sm text-gray-500">{{ $entry->branch->city ?? '' }}</div>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <div class="text-sm text-gray-900">
+                                @if($entry->purchaseOrder)
+                                    #{{ $entry->purchaseOrder->id }}
+                                @else
+                                    N/A
+                                @endif
+                            </div>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            @php
+                                $statusColors = [
+                                    'pending' => 'bg-yellow-100 text-yellow-800',
+                                    'completed' => 'bg-green-100 text-green-800',
+                                    'discrepancy' => 'bg-red-100 text-red-800',
+                                    'cancelled' => 'bg-gray-100 text-gray-800'
+                                ];
+                                $statusColor = $statusColors[$entry->status] ?? 'bg-gray-100 text-gray-800';
+                            @endphp
+                            <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full {{ $statusColor }}">
+                                {{ ucfirst($entry->status) }}
+                            </span>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <div class="text-sm font-medium text-gray-900">
+                                ₹{{ number_format($entry->total_amount, 2) }}
+                            </div>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                            {{ $entry->created_at->format('M d, Y H:i') }}
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                            <div class="flex space-x-2">
+                                <a href="{{ route('branch.purchase-entries.show', $entry->id) }}" 
+                                   class="text-blue-600 hover:text-blue-900 transition-colors">
+                                    <i class="fas fa-eye"></i>
+                                </a>
+                                @if($entry->status === 'discrepancy')
+                                <button onclick="resolveDiscrepancy({{ $entry->id }})" 
+                                        class="text-green-600 hover:text-green-900 transition-colors">
+                                    <i class="fas fa-check"></i>
+                                </button>
+                                @endif
+                            </div>
+                        </td>
+                    </tr>
+                    @empty
+                    <tr>
+                        <td colspan="7" class="px-6 py-12 text-center">
+                            <div class="text-gray-500">
+                                <i class="fas fa-receipt text-4xl mb-4"></i>
+                                <p class="text-lg font-medium">No purchase entries found</p>
+                                <p class="text-sm">Purchase entries will appear here once branches start creating them.</p>
+                            </div>
+                        </td>
+                    </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Pagination -->
+        @if($purchaseEntries->hasPages())
+        <div class="px-6 py-4 border-t border-gray-200">
+            {{ $purchaseEntries->links() }}
+        </div>
+        @endif
+    </div>
+</div>
+
+<script>
+function refreshData() {
+    location.reload();
+}
+
+function resolveDiscrepancy(entryId) {
+    if (confirm('Are you sure you want to mark this discrepancy as resolved?')) {
+        // Here you would typically make an AJAX call to resolve the discrepancy
+        // For now, we'll just show an alert
+        alert('Discrepancy resolution functionality would be implemented here.');
+    }
+}
+</script>
+@endsection

--- a/resources/views/partials/navigation/super-admin.blade.php
+++ b/resources/views/partials/navigation/super-admin.blade.php
@@ -73,6 +73,13 @@
         <span class="font-medium">Orders from Branches</span>
     </a>
 
+    <a href="{{ route('admin.purchase-entries.index') }}" class="nav-link flex items-center p-3 rounded-xl text-gray-300 {{ request()->routeIs('admin.purchase-entries.*') ? 'active text-white' : '' }}">
+        <div class="nav-icon rounded-lg flex items-center justify-center mr-3">
+            <i class="fas fa-receipt"></i>
+        </div>
+        <span class="font-medium">Purchase Entries</span>
+    </a>
+
     <!-- Analytics & Reports -->
     <div class="pt-4 pb-2">
         <p class="text-xs font-semibold text-gray-400 uppercase tracking-wider px-3">Analytics & Reports</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -262,6 +262,9 @@ Route::middleware('auth')->group(function () {
         // Role Management
         Route::get('/admin/roles', [AdminController::class, 'roles'])->name('admin.roles');
         
+        // Purchase Entries Management
+        Route::get('/admin/purchase-entries', [AdminController::class, 'purchaseEntries'])->name('admin.purchase-entries.index');
+        
         // System Settings
         Route::get('/admin/settings', [AdminController::class, 'settings'])->name('admin.settings');
         Route::get('/admin/security', [AdminController::class, 'security'])->name('admin.security');


### PR DESCRIPTION
Add a 'Purchase Entries' shortcut to the super admin sidebar to provide a centralized view of all purchase entries across branches.

---
<a href="https://cursor.com/background-agent?bcId=bc-8555a6d7-0785-4173-ac26-ba789c521f6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8555a6d7-0785-4173-ac26-ba789c521f6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

