### PR TITLE
Sync product orders with purchase entries

### DIFF
--- a/app/Http/Controllers/Web/BranchPurchaseEntryController.php
+++ b/app/Http/Controllers/Web/BranchPurchaseEntryController.php
@@ -301,11 +301,12 @@ class BranchPurchaseEntryController extends Controller
                 }
             }
             
-            // Update purchase order receive status
-            $purchaseEntry->updateReceiveStatus();
+            // Update purchase order receive status using normalized aggregates
+            $purchaseEntry->recalculateReceiptAggregates();
             
             // Update purchase order status if complete receipt
             if (!$isPartialReceipt) {
+                // recalc will auto-mark order as received; keep PO status aligned
                 $purchaseEntry->update(['status' => 'received']);
             }
         });

--- a/app/Http/Controllers/Web/EnhancedPurchaseEntryController.php
+++ b/app/Http/Controllers/Web/EnhancedPurchaseEntryController.php
@@ -64,10 +64,15 @@ class EnhancedPurchaseEntryController extends Controller
 
         $purchaseOrders = $query->latest('created_at')->paginate(15);
 
-        // Calculate detailed statistics for each order
+        // Calculate detailed statistics for each order using normalized aggregates
         $purchaseOrders->getCollection()->transform(function ($order) {
+            $order->recalculateReceiptAggregates();
             $order->total_expected = $order->purchaseOrderItems->sum('quantity');
-            $order->total_received = $order->purchaseEntries->sum('total_received_quantity');
+            $order->total_received = (float) $order->purchaseOrderItems->sum(function ($item) {
+                $direct = (float) ($item->received_quantity ?? 0);
+                $fromEntries = (float) ($item->actual_received_quantity ?? 0);
+                return max($direct, $fromEntries);
+            });
             $order->total_remaining = $order->total_expected - $order->total_received;
             $order->total_spoiled = $order->purchaseEntries->sum('total_spoiled_quantity');
             $order->total_damaged = $order->purchaseEntries->sum('total_damaged_quantity');
@@ -116,6 +121,9 @@ class EnhancedPurchaseEntryController extends Controller
             abort(403, 'Access denied.');
         }
 
+        // Ensure aggregates are up-to-date before display
+        $purchaseOrder->recalculateReceiptAggregates();
+
         $purchaseOrder->load([
             'vendor', 
             'user', 
@@ -129,10 +137,12 @@ class EnhancedPurchaseEntryController extends Controller
 
         // Calculate detailed tracking for each item
         $itemTracking = $purchaseOrder->purchaseOrderItems->map(function ($item) use ($purchaseOrder) {
-            $totalReceived = $purchaseOrder->purchaseEntries
+            $receivedFromEntries = $purchaseOrder->purchaseEntries
                 ->flatMap->purchaseEntryItems
                 ->where('product_id', $item->product_id)
                 ->sum('received_quantity');
+            $direct = (float) ($item->received_quantity ?? 0);
+            $totalReceived = max($direct, (float) $receivedFromEntries);
             
             $totalSpoiled = $purchaseOrder->purchaseEntries
                 ->flatMap->purchaseEntryItems
@@ -169,13 +179,25 @@ class EnhancedPurchaseEntryController extends Controller
         // Calculate overall order statistics
         $orderStats = [
             'total_expected' => $purchaseOrder->purchaseOrderItems->sum('quantity'),
-            'total_received' => $purchaseOrder->purchaseEntries->sum('total_received_quantity'),
-            'total_remaining' => $purchaseOrder->purchaseOrderItems->sum('quantity') - $purchaseOrder->purchaseEntries->sum('total_received_quantity'),
+            'total_received' => (float) $purchaseOrder->purchaseOrderItems->sum(function ($item) {
+                $direct = (float) ($item->received_quantity ?? 0);
+                $fromEntries = (float) ($item->actual_received_quantity ?? 0);
+                return max($direct, $fromEntries);
+            }),
+            'total_remaining' => $purchaseOrder->purchaseOrderItems->sum('quantity') - (float) $purchaseOrder->purchaseOrderItems->sum(function ($item) {
+                $direct = (float) ($item->received_quantity ?? 0);
+                $fromEntries = (float) ($item->actual_received_quantity ?? 0);
+                return max($direct, $fromEntries);
+            }),
             'total_spoiled' => $purchaseOrder->purchaseEntries->sum('total_spoiled_quantity'),
             'total_damaged' => $purchaseOrder->purchaseEntries->sum('total_damaged_quantity'),
             'total_usable' => $purchaseOrder->purchaseEntries->sum('total_usable_quantity'),
             'completion_percentage' => $purchaseOrder->purchaseOrderItems->sum('quantity') > 0 ? 
-                ($purchaseOrder->purchaseEntries->sum('total_received_quantity') / $purchaseOrder->purchaseOrderItems->sum('quantity')) * 100 : 0,
+                (((float) $purchaseOrder->purchaseOrderItems->sum(function ($item) {
+                    $direct = (float) ($item->received_quantity ?? 0);
+                    $fromEntries = (float) ($item->actual_received_quantity ?? 0);
+                    return max($direct, $fromEntries);
+                })) / $purchaseOrder->purchaseOrderItems->sum('quantity')) * 100 : 0,
             'receipt_count' => $purchaseOrder->purchaseEntries->count(),
         ];
 
@@ -238,6 +260,29 @@ class EnhancedPurchaseEntryController extends Controller
         
         if ($purchaseOrder->branch_id !== $user->branch_id) {
             abort(403, 'Access denied.');
+        }
+
+        // Pre-validate: ensure no item exceeds ordered quantity when combined with previous entries
+        foreach ($request->items as $itemData) {
+            $purchaseOrderItem = PurchaseOrderItem::findOrFail($itemData['item_id']);
+            if ($purchaseOrderItem->purchase_order_id !== $purchaseOrder->id) {
+                abort(422, 'Invalid item reference.');
+            }
+
+            $receivedQuantity = (float) $itemData['received_quantity'];
+            $spoiledQuantity = (float) ($itemData['spoiled_quantity'] ?? 0);
+            $damagedQuantity = (float) ($itemData['damaged_quantity'] ?? 0);
+
+            if ($spoiledQuantity + $damagedQuantity > $receivedQuantity) {
+                return back()->withInput()->withErrors(['items' => 'Spoiled + Damaged cannot exceed Received quantity for product ID ' . $purchaseOrderItem->product_id]);
+            }
+
+            $previouslyReceived = (float) PurchaseEntryItem::where('purchase_order_item_id', $purchaseOrderItem->id)
+                ->sum('received_quantity');
+            $ordered = (float) $purchaseOrderItem->quantity;
+            if ($previouslyReceived + $receivedQuantity > $ordered + 0.00001) {
+                return back()->withInput()->withErrors(['items' => 'Total received cannot exceed ordered quantity for product ' . ($purchaseOrderItem->product->name ?? ('#' . $purchaseOrderItem->product_id))]);
+            }
         }
 
         DB::transaction(function () use ($request, $purchaseOrder, $user) {
@@ -373,8 +418,8 @@ class EnhancedPurchaseEntryController extends Controller
                 'entry_status' => ($totalSpoiled > 0 || $totalDamaged > 0) ? 'discrepancy' : 'received',
             ]);
 
-            // Update purchase order receive status
-            $purchaseOrder->updateReceiveStatus();
+            // Update purchase order receive status and aggregates
+            $purchaseOrder->recalculateReceiptAggregates();
         });
 
         return redirect()->route('enhanced-purchase-entries.show', $purchaseOrder)
@@ -445,5 +490,233 @@ class EnhancedPurchaseEntryController extends Controller
             ($overallStats['total_loss'] / $overallStats['total_received']) * 100 : 0;
 
         return view('branch.enhanced-purchase-entries.report', compact('entries', 'overallStats'));
+    }
+
+    /**
+     * Edit a purchase entry (adjust quantities with validation).
+     */
+    public function editEntry(PurchaseEntry $purchaseEntry)
+    {
+        $user = Auth::user();
+        if (!$user->hasRole('branch_manager') || $purchaseEntry->branch_id !== $user->branch_id) {
+            abort(403, 'Access denied.');
+        }
+
+        $purchaseEntry->load(['purchaseOrder.purchaseOrderItems', 'purchaseEntryItems.product']);
+
+        // Compute per-item maximum allowed received considering other entries
+        $limits = [];
+        foreach ($purchaseEntry->purchaseEntryItems as $entryItem) {
+            $poItemId = $entryItem->purchase_order_item_id;
+            $poItem = $purchaseEntry->purchaseOrder->purchaseOrderItems->firstWhere('id', $poItemId);
+            $otherReceived = (float) PurchaseEntryItem::where('purchase_order_item_id', $poItemId)
+                ->where('purchase_entry_id', '!=', $purchaseEntry->id)
+                ->sum('received_quantity');
+            $limits[$entryItem->id] = [
+                'max_received' => max(0, (float) $poItem->quantity - $otherReceived) + (float) $entryItem->received_quantity,
+            ];
+        }
+
+        return view('branch.enhanced-purchase-entries.edit-entry', compact('purchaseEntry', 'limits'));
+    }
+
+    /**
+     * Update a purchase entry after editing quantities.
+     */
+    public function updateEntry(Request $request, PurchaseEntry $purchaseEntry)
+    {
+        $user = Auth::user();
+        if (!$user->hasRole('branch_manager') || $purchaseEntry->branch_id !== $user->branch_id) {
+            abort(403, 'Access denied.');
+        }
+
+        $request->validate([
+            'items' => 'required|array',
+            'items.*.id' => 'required|exists:purchase_entry_items,id',
+            'items.*.received_quantity' => 'required|numeric|min:0',
+            'items.*.spoiled_quantity' => 'nullable|numeric|min:0',
+            'items.*.damaged_quantity' => 'nullable|numeric|min:0',
+            'items.*.quality_notes' => 'nullable|string',
+        ]);
+
+        DB::transaction(function () use ($request, $purchaseEntry, $user) {
+            $purchaseEntry->load(['purchaseOrder.purchaseOrderItems', 'purchaseEntryItems']);
+
+            // Validate against ordered quantities
+            foreach ($request->items as $data) {
+                $entryItem = $purchaseEntry->purchaseEntryItems->firstWhere('id', $data['id']);
+                if (!$entryItem) {
+                    abort(422, 'Invalid entry item.');
+                }
+                $poItemId = $entryItem->purchase_order_item_id;
+                $poItem = $purchaseEntry->purchaseOrder->purchaseOrderItems->firstWhere('id', $poItemId);
+                $newReceived = (float) $data['received_quantity'];
+                $spoiled = (float) ($data['spoiled_quantity'] ?? 0);
+                $damaged = (float) ($data['damaged_quantity'] ?? 0);
+                if ($spoiled + $damaged > $newReceived) {
+                    abort(422, 'Spoiled + Damaged cannot exceed Received for product ' . ($entryItem->product->name ?? '#'.$entryItem->product_id));
+                }
+                $otherReceived = (float) PurchaseEntryItem::where('purchase_order_item_id', $poItemId)
+                    ->where('purchase_entry_id', '!=', $purchaseEntry->id)
+                    ->sum('received_quantity');
+                if ($otherReceived + $newReceived > (float) $poItem->quantity + 0.00001) {
+                    abort(422, 'Total received cannot exceed ordered for product ' . ($entryItem->product->name ?? '#'.$entryItem->product_id));
+                }
+            }
+
+            // Remove previous stock movements for this entry to re-create cleanly
+            StockMovement::where('reference_type', 'purchase_entry')
+                ->where('reference_id', $purchaseEntry->id)
+                ->delete();
+            StockMovement::where('reference_type', 'purchase_entry_spoilage')
+                ->where('reference_id', $purchaseEntry->id)
+                ->delete();
+            StockMovement::where('reference_type', 'purchase_entry_damage')
+                ->where('reference_id', $purchaseEntry->id)
+                ->delete();
+
+            $totalExpected = 0;
+            $totalReceived = 0;
+            $totalSpoiled = 0;
+            $totalDamaged = 0;
+            $totalUsable = 0;
+            $totalExpectedWeight = 0;
+            $totalActualWeight = 0;
+
+            foreach ($request->items as $data) {
+                $entryItem = $purchaseEntry->purchaseEntryItems->firstWhere('id', $data['id']);
+                $poItem = $purchaseEntry->purchaseOrder->purchaseOrderItems->firstWhere('id', $entryItem->purchase_order_item_id);
+
+                $newReceived = (float) $data['received_quantity'];
+                $spoiled = (float) ($data['spoiled_quantity'] ?? 0);
+                $damaged = (float) ($data['damaged_quantity'] ?? 0);
+                $usable = $newReceived - $spoiled - $damaged;
+                $oldUsable = (float) $entryItem->usable_quantity;
+
+                $entryItem->update([
+                    'received_quantity' => $newReceived,
+                    'spoiled_quantity' => $spoiled,
+                    'damaged_quantity' => $damaged,
+                    'usable_quantity' => $usable,
+                    'quality_notes' => $data['quality_notes'] ?? $entryItem->quality_notes,
+                    'total_price' => $usable * (float) $entryItem->unit_price,
+                ]);
+
+                // Adjust product branch stock based on delta usable
+                $deltaUsable = $usable - $oldUsable;
+                if (abs($deltaUsable) > 0.00001) {
+                    $product = $entryItem->product;
+                    $currentStock = $product->getCurrentStock($purchaseEntry->branch_id);
+                    $product->updateBranchStock($purchaseEntry->branch_id, $currentStock + $deltaUsable);
+                }
+
+                // Totals
+                $totalExpected += (float) $poItem->quantity;
+                $totalReceived += $newReceived;
+                $totalSpoiled += $spoiled;
+                $totalDamaged += $damaged;
+                $totalUsable += $usable;
+                $totalExpectedWeight += (float) ($entryItem->expected_weight ?? 0);
+                $totalActualWeight += (float) ($entryItem->actual_weight ?? 0);
+
+                // Recreate stock movements
+                if ($usable > 0) {
+                    StockMovement::create([
+                        'product_id' => $entryItem->product_id,
+                        'branch_id' => $purchaseEntry->branch_id,
+                        'type' => 'purchase',
+                        'quantity' => $usable,
+                        'unit_price' => $entryItem->unit_price,
+                        'reference_type' => 'purchase_entry',
+                        'reference_id' => $purchaseEntry->id,
+                        'user_id' => $user->id,
+                        'notes' => "Purchase Entry Updated: {$purchaseEntry->entry_number}",
+                    ]);
+                }
+                if ($spoiled > 0) {
+                    StockMovement::create([
+                        'product_id' => $entryItem->product_id,
+                        'branch_id' => $purchaseEntry->branch_id,
+                        'type' => 'loss',
+                        'quantity' => $spoiled,
+                        'unit_price' => $entryItem->unit_price,
+                        'reference_type' => 'purchase_entry_spoilage',
+                        'reference_id' => $purchaseEntry->id,
+                        'user_id' => $user->id,
+                        'notes' => "Purchase Entry Spoilage Updated: {$purchaseEntry->entry_number}",
+                    ]);
+                }
+                if ($damaged > 0) {
+                    StockMovement::create([
+                        'product_id' => $entryItem->product_id,
+                        'branch_id' => $purchaseEntry->branch_id,
+                        'type' => 'loss',
+                        'quantity' => $damaged,
+                        'unit_price' => $entryItem->unit_price,
+                        'reference_type' => 'purchase_entry_damage',
+                        'reference_id' => $purchaseEntry->id,
+                        'user_id' => $user->id,
+                        'notes' => "Purchase Entry Damage Updated: {$purchaseEntry->entry_number}",
+                    ]);
+                }
+            }
+
+            // Update entry totals
+            $purchaseEntry->update([
+                'total_expected_quantity' => $totalExpected,
+                'total_received_quantity' => $totalReceived,
+                'total_spoiled_quantity' => $totalSpoiled,
+                'total_damaged_quantity' => $totalDamaged,
+                'total_usable_quantity' => $totalUsable,
+                'total_expected_weight' => $totalExpectedWeight ?: null,
+                'total_actual_weight' => $totalActualWeight ?: null,
+                'total_weight_difference' => ($totalActualWeight ?: 0) - ($totalExpectedWeight ?: 0),
+                'entry_status' => ($totalSpoiled > 0 || $totalDamaged > 0) ? 'discrepancy' : 'received',
+            ]);
+
+            // Recalculate order aggregates
+            optional($purchaseEntry->purchaseOrder)->recalculateReceiptAggregates();
+        });
+
+        return redirect()->route('enhanced-purchase-entries.entry', $purchaseEntry)
+            ->with('success', 'Purchase entry updated successfully!');
+    }
+
+    /**
+     * Delete a purchase entry and roll back aggregates and stock movements.
+     */
+    public function destroyEntry(PurchaseEntry $purchaseEntry)
+    {
+        $user = Auth::user();
+        if (!$user->hasRole('branch_manager') || $purchaseEntry->branch_id !== $user->branch_id) {
+            abort(403, 'Access denied.');
+        }
+
+        DB::transaction(function () use ($purchaseEntry) {
+            // Delete related stock movements for this entry
+            StockMovement::whereIn('reference_type', ['purchase_entry', 'purchase_entry_spoilage', 'purchase_entry_damage'])
+                ->where('reference_id', $purchaseEntry->id)
+                ->delete();
+
+            // Before delete, rollback branch stock by subtracting usable quantities
+            $purchaseEntry->loadMissing('purchaseEntryItems.product');
+            foreach ($purchaseEntry->purchaseEntryItems as $entryItem) {
+                $usable = (float) $entryItem->usable_quantity;
+                if ($usable > 0) {
+                    $product = $entryItem->product;
+                    $currentStock = $product->getCurrentStock($purchaseEntry->branch_id);
+                    $product->updateBranchStock($purchaseEntry->branch_id, $currentStock - $usable);
+                }
+            }
+
+            $order = $purchaseEntry->purchaseOrder()->first();
+            $purchaseEntry->delete();
+            if ($order) {
+                $order->recalculateReceiptAggregates();
+            }
+        });
+
+        return redirect()->route('enhanced-purchase-entries.index')
+            ->with('success', 'Purchase entry deleted. Aggregates updated.');
     }
 }

--- a/app/Http/Controllers/Web/PurchaseOrderController.php
+++ b/app/Http/Controllers/Web/PurchaseOrderController.php
@@ -430,7 +430,7 @@ class PurchaseOrderController extends Controller
      */
     public function receive(Request $request, PurchaseOrder $purchaseOrder)
     {
-        if (!$purchaseOrder->isConfirmed()) {
+        if (!$purchaseOrder->isConfirmed() && !$purchaseOrder->isFulfilled() && !$purchaseOrder->isSent()) {
             return redirect()->route('purchase-orders.show', $purchaseOrder)
                 ->with('error', 'Only confirmed purchase orders can be received.');
         }
@@ -506,13 +506,11 @@ class PurchaseOrderController extends Controller
                     ]);
                 }
                 
-                // Update receive status and totals
-                $purchaseOrder->updateReceiveStatus();
+                // Update receive status and totals using normalized aggregates
+                $purchaseOrder->recalculateReceiptAggregates();
                 
                 // If all items are fully received, mark as complete
-                if ($allItemsReceived) {
-                    $purchaseOrder->markAsReceived();
-                }
+                // recalculateReceiptAggregates already auto-marks as received when complete
             }
         });
 

--- a/app/Models/PurchaseEntryItem.php
+++ b/app/Models/PurchaseEntryItem.php
@@ -135,4 +135,21 @@ class PurchaseEntryItem extends Model
         
         return 'none';
     }
+
+    protected static function booted(): void
+    {
+        // Recalculate parent order aggregates when entry items change
+        $recalc = function (self $item) {
+            $entry = $item->purchaseEntry()->first();
+            if ($entry) {
+                $order = $entry->purchaseOrder()->first();
+                if ($order) {
+                    $order->recalculateReceiptAggregates();
+                }
+            }
+        };
+
+        static::saved($recalc);
+        static::deleted($recalc);
+    }
 }

--- a/app/Models/PurchaseOrder.php
+++ b/app/Models/PurchaseOrder.php
@@ -387,23 +387,8 @@ class PurchaseOrder extends Model
      */
     public function updateReceiveStatus(): void
     {
-        $this->load('purchaseOrderItems');
-        
-        $totalOrdered = $this->purchaseOrderItems->sum('quantity');
-        $totalReceived = $this->purchaseOrderItems->sum('received_quantity');
-        
-        $this->total_ordered_quantity = $totalOrdered;
-        $this->total_received_quantity = $totalReceived;
-        
-        if ($totalReceived == 0) {
-            $this->receive_status = 'not_received';
-        } elseif ($totalReceived >= $totalOrdered) {
-            $this->receive_status = 'complete';
-        } else {
-            $this->receive_status = 'partial';
-        }
-        
-        $this->save();
+        // Ensure aggregates are up-to-date and then persist status based on effective totals
+        $this->recalculateReceiptAggregates();
     }
 
     /**
@@ -470,7 +455,12 @@ class PurchaseOrder extends Model
     public function getRemainingQuantity(): float
     {
         $totalOrdered = $this->purchaseOrderItems->sum('quantity');
-        $totalReceived = $this->getTotalReceivedQuantity();
+        // Use normalized item-level received quantities for remaining calc
+        $totalReceived = $this->purchaseOrderItems->sum(function ($item) {
+            $direct = (float) ($item->received_quantity ?? 0);
+            $fromEntries = (float) ($item->actual_received_quantity ?? 0);
+            return max($direct, $fromEntries);
+        });
         return max(0, $totalOrdered - $totalReceived);
     }
 
@@ -483,9 +473,13 @@ class PurchaseOrder extends Model
         if ($totalOrdered == 0) {
             return 0;
         }
-        
-        $totalReceived = $this->getTotalReceivedQuantity();
-        return ($totalReceived / $totalOrdered) * 100;
+        // Use normalized item-level received quantities for completion calc
+        $totalReceived = $this->purchaseOrderItems->sum(function ($item) {
+            $direct = (float) ($item->received_quantity ?? 0);
+            $fromEntries = (float) ($item->actual_received_quantity ?? 0);
+            return max($direct, $fromEntries);
+        });
+        return $totalOrdered > 0 ? ($totalReceived / $totalOrdered) * 100 : 0;
     }
 
     /**
@@ -552,5 +546,120 @@ class PurchaseOrder extends Model
                 'has_discrepancies' => $totalSpoiled > 0 || $totalDamaged > 0,
             ];
         })->toArray();
+    }
+
+    /**
+     * Recalculate and synchronize receipt aggregates across order, items, and entries.
+     * - Aggregates entry items by purchase order item
+     * - Normalizes item.received_quantity using max(direct, fromEntries)
+     * - Updates order total ordered/received quantities and receive_status
+     * - If completely received, marks status as 'received' (does not change order_type)
+     */
+    public function recalculateReceiptAggregates(): void
+    {
+        $this->loadMissing([
+            'purchaseOrderItems',
+            'purchaseEntries.purchaseEntryItems',
+        ]);
+
+        // Build quick lookup of aggregated entry quantities keyed by purchase_order_item_id
+        $entryItems = $this->purchaseEntries
+            ->flatMap(function ($entry) {
+                return $entry->purchaseEntryItems;
+            });
+
+        $aggregatedByPoItemId = $entryItems
+            ->groupBy('purchase_order_item_id')
+            ->map(function ($group) {
+                return [
+                    'received' => (float) $group->sum('received_quantity'),
+                    'spoiled' => (float) $group->sum('spoiled_quantity'),
+                    'damaged' => (float) $group->sum('damaged_quantity'),
+                    'usable' => (float) $group->sum('usable_quantity'),
+                    'expected_weight' => (float) $group->sum(function ($i) { return (float) ($i->expected_weight ?? 0); }),
+                    'actual_weight' => (float) $group->sum(function ($i) { return (float) ($i->actual_weight ?? 0); }),
+                ];
+            });
+
+        // Synchronize each order item with aggregated entry data
+        foreach ($this->purchaseOrderItems as $orderItem) {
+            $agg = $aggregatedByPoItemId->get($orderItem->id, [
+                'received' => 0.0,
+                'spoiled' => 0.0,
+                'damaged' => 0.0,
+                'usable' => 0.0,
+                'expected_weight' => 0.0,
+                'actual_weight' => 0.0,
+            ]);
+
+            $directReceived = (float) ($orderItem->received_quantity ?? 0);
+            $fromEntries = (float) $agg['received'];
+            $normalizedReceived = max($directReceived, $fromEntries);
+
+            $orderItem->received_quantity = $normalizedReceived;
+            // Only override actuals from entries if we have entry-based data
+            if ($fromEntries > 0) {
+                $orderItem->actual_received_quantity = $fromEntries;
+            }
+            if ($agg['spoiled'] > 0) {
+                $orderItem->spoiled_quantity = $agg['spoiled'];
+            }
+            if ($agg['damaged'] > 0) {
+                $orderItem->damaged_quantity = $agg['damaged'];
+            }
+            if ($agg['usable'] > 0) {
+                $orderItem->usable_quantity = $agg['usable'];
+            }
+            $newExpectedWeight = $agg['expected_weight'] > 0 ? $agg['expected_weight'] : $orderItem->expected_weight;
+            $newActualWeight = $agg['actual_weight'] > 0 ? $agg['actual_weight'] : $orderItem->actual_weight;
+            $orderItem->expected_weight = $newExpectedWeight;
+            $orderItem->actual_weight = $newActualWeight;
+            $orderItem->weight_difference = ($newActualWeight !== null && $newExpectedWeight !== null)
+                ? ($newActualWeight - $newExpectedWeight)
+                : $orderItem->weight_difference;
+            if ($orderItem->isDirty()) {
+                $orderItem->saveQuietly();
+            }
+        }
+
+        // Update order-level totals and status
+        $totalOrdered = (float) $this->purchaseOrderItems->sum('quantity');
+        $totalReceivedFromItems = (float) $this->purchaseOrderItems->sum(function ($item) {
+            $direct = (float) ($item->received_quantity ?? 0);
+            $fromEntries = (float) ($item->actual_received_quantity ?? 0);
+            return max($direct, $fromEntries);
+        });
+        $totalReceivedFromEntries = (float) $this->purchaseEntries->sum('total_received_quantity');
+
+        $effectiveTotalReceived = max($totalReceivedFromItems, $totalReceivedFromEntries);
+
+        $newReceiveStatus = 'not_received';
+        if ($effectiveTotalReceived <= 0) {
+            $newReceiveStatus = 'not_received';
+        } elseif ($effectiveTotalReceived + 0.00001 >= $totalOrdered && $totalOrdered > 0) {
+            $newReceiveStatus = 'complete';
+        } else {
+            $newReceiveStatus = 'partial';
+        }
+
+        $updates = [
+            'total_ordered_quantity' => $totalOrdered,
+            'total_received_quantity' => $effectiveTotalReceived,
+            'receive_status' => $newReceiveStatus,
+        ];
+
+        // Auto-mark as received when completed
+        if ($newReceiveStatus === 'complete' && $this->status !== 'received') {
+            $updates['status'] = 'received';
+            if (!$this->received_at) {
+                $updates['received_at'] = now();
+                // Keep received_by unchanged unless set elsewhere
+            }
+        }
+
+        $this->fill($updates);
+        if ($this->isDirty()) {
+            $this->saveQuietly();
+        }
     }
 }

--- a/app/Models/PurchaseOrderItem.php
+++ b/app/Models/PurchaseOrderItem.php
@@ -77,4 +77,18 @@ class PurchaseOrderItem extends Model
         $this->total_price = $this->calculateTotalPrice();
         $this->save();
     }
+
+    protected static function booted(): void
+    {
+        // When a PO item is saved/deleted, recalc parent PO aggregates
+        $recalc = function (self $item) {
+            $order = $item->purchaseOrder()->first();
+            if ($order) {
+                $order->recalculateReceiptAggregates();
+            }
+        };
+
+        static::saved($recalc);
+        static::deleted($recalc);
+    }
 }

--- a/resources/views/branch/enhanced-purchase-entries/entry.blade.php
+++ b/resources/views/branch/enhanced-purchase-entries/entry.blade.php
@@ -17,6 +17,22 @@
                 </svg>
                 Back to Order
             </a>
+            <a href="{{ route('enhanced-purchase-entries.entry.edit', $purchaseEntry) }}" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-lg transition-colors">
+                <svg class="h-4 w-4 inline mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536M7.5 21H3v-4.5L16.732 2.768a2.5 2.5 0 113.536 3.536L6.536 20.036A2 2 0 015 20.5V21z" />
+                </svg>
+                Edit Entry
+            </a>
+            <form method="POST" action="{{ route('enhanced-purchase-entries.entry.destroy', $purchaseEntry) }}" onsubmit="return confirm('Delete this entry? This will roll back received quantities.');">
+                @csrf
+                @method('DELETE')
+                <button type="submit" class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded-lg transition-colors">
+                    <svg class="h-4 w-4 inline mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7h6m2 0H7m4-3h2a1 1 0 011 1v2H8V5a1 1 0 011-1z" />
+                    </svg>
+                    Delete Entry
+                </button>
+            </form>
         </div>
     </div>
 
@@ -99,7 +115,7 @@
                 </div>
                 <div class="flex justify-between">
                     <span class="text-gray-600">Order Number:</span>
-                    <span class="font-medium">{{ $purchaseEntry->purchaseOrder->po_number }}</span>
+                    <a href="{{ route('enhanced-purchase-entries.show', $purchaseEntry->purchaseOrder) }}" class="font-medium text-blue-600 hover:text-blue-800">{{ $purchaseEntry->purchaseOrder->po_number }}</a>
                 </div>
                 <div class="flex justify-between">
                     <span class="text-gray-600">Entry Date:</span>

--- a/resources/views/branch/product-orders/show.blade.php
+++ b/resources/views/branch/product-orders/show.blade.php
@@ -47,6 +47,9 @@
                     <div class="bg-gray-50 rounded-lg p-4">
                         <div class="text-xs text-gray-500">Status</div>
                         <div class="text-sm font-medium text-gray-900">{{ ucfirst($productOrder->status) }}</div>
+                        <div class="mt-1 text-xs">
+                            <span class="inline-flex items-center px-2 py-0.5 rounded {{ $productOrder->getReceiveStatusBadgeClass() }}">{{ $productOrder->getReceiveStatusDisplayText() }}</span>
+                        </div>
                     </div>
                 </div>
 
@@ -127,6 +130,19 @@
             <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mt-6">
                 <h2 class="text-lg font-semibold text-gray-900 mb-2">Actions</h2>
                 <button type="button" onclick="document.getElementById('receiveModal').classList.remove('hidden')" class="btn btn-success w-full">Receive Remaining Items</button>
+            </div>
+            @endif
+            @if($productOrder->purchaseEntries->count() > 0)
+            <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mt-6">
+                <h2 class="text-lg font-semibold text-gray-900 mb-3">Receipt Entries</h2>
+                <ul class="space-y-2 text-sm">
+                    @foreach($productOrder->purchaseEntries as $entry)
+                    <li class="flex justify-between">
+                        <a href="{{ route('enhanced-purchase-entries.entry', $entry) }}" class="text-blue-600 hover:text-blue-800">{{ $entry->entry_number }}</a>
+                        <span class="text-gray-600">{{ $entry->entry_date->format('M d, Y') }}</span>
+                    </li>
+                    @endforeach
+                </ul>
             </div>
             @endif
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -313,6 +313,9 @@ Route::middleware('auth')->group(function () {
         Route::get('/enhanced-purchase-entries/{purchaseOrder}', [EnhancedPurchaseEntryController::class, 'show'])->name('enhanced-purchase-entries.show');
         Route::get('/enhanced-purchase-entries/entry/{purchaseEntry}', [EnhancedPurchaseEntryController::class, 'showEntry'])->name('enhanced-purchase-entries.entry');
         Route::get('/enhanced-purchase-entries/report', [EnhancedPurchaseEntryController::class, 'report'])->name('enhanced-purchase-entries.report');
+        Route::get('/enhanced-purchase-entries/entry/{purchaseEntry}/edit', [EnhancedPurchaseEntryController::class, 'editEntry'])->name('enhanced-purchase-entries.entry.edit');
+        Route::put('/enhanced-purchase-entries/entry/{purchaseEntry}', [EnhancedPurchaseEntryController::class, 'updateEntry'])->name('enhanced-purchase-entries.entry.update');
+        Route::delete('/enhanced-purchase-entries/entry/{purchaseEntry}', [EnhancedPurchaseEntryController::class, 'destroyEntry'])->name('enhanced-purchase-entries.entry.destroy');
         
         // API routes for enhanced purchase entries
         Route::get('/api/purchase-orders/{purchaseOrder}/items', function($purchaseOrderId) {


### PR DESCRIPTION
Implement automatic synchronization between Product Orders and Purchase Entries to ensure accurate, real-time received quantities and status across all receipt methods.

Previously, Product Orders failed to reflect received quantities from Purchase Entries, leading to discrepancies between direct receipts and entry-based receipts. This PR introduces a unified `recalculateReceiptAggregates` method and model observers to ensure all receipt flows consistently update order status and item quantities.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6178f98-e76a-49db-9dee-e07087985cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e6178f98-e76a-49db-9dee-e07087985cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

