### PR TITLE
Handle duplicate purchase order number

### DIFF
--- a/app/Http/Controllers/Web/AdminBranchOrderController.php
+++ b/app/Http/Controllers/Web/AdminBranchOrderController.php
@@ -9,6 +9,7 @@ use App\Models\Vendor;
 use App\Models\Branch;
 use App\Models\Product;
 use App\Models\StockMovement;
+use App\Models\PoNumberSequence;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
@@ -130,7 +131,7 @@ class AdminBranchOrderController extends Controller
         DB::transaction(function () use ($request, $branchOrder) {
             // Create a new purchase order for the vendor
             $vendorPO = PurchaseOrder::create([
-                'po_number' => 'PO-' . date('Y') . '-' . str_pad(PurchaseOrder::max('id') + 1, 4, '0', STR_PAD_LEFT),
+                'po_number' => PoNumberSequence::getNextPoNumber('purchase_order', now()->year),
                 'vendor_id' => $request->vendor_id,
                 'branch_id' => $branchOrder->branch_id, // Admin's main branch
                 'branch_request_id' => $branchOrder->id, // Link to the original branch request

--- a/app/Http/Controllers/Web/PurchaseOrderController.php
+++ b/app/Http/Controllers/Web/PurchaseOrderController.php
@@ -9,6 +9,7 @@ use App\Models\Vendor;
 use App\Models\Branch;
 use App\Models\Product;
 use App\Models\StockMovement;
+use App\Models\PoNumberSequence;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
@@ -186,8 +187,8 @@ class PurchaseOrderController extends Controller
             $purchaseOrder = DB::transaction(function () use ($request) {
                 \Log::info('Purchase Order Transaction Started');
                 
-                // Generate PO number
-                $poNumber = 'PO-' . date('Y') . '-' . str_pad(PurchaseOrder::count() + 1, 4, '0', STR_PAD_LEFT);
+                // Generate PO number using atomic sequence generation
+                $poNumber = PoNumberSequence::getNextPoNumber('purchase_order', now()->year);
                 \Log::info('Generated PO Number: ' . $poNumber);
 
                 // Pre-calculate totals to satisfy NOT NULL DB constraints on insert

--- a/app/Models/PoNumberSequence.php
+++ b/app/Models/PoNumberSequence.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+
+class PoNumberSequence extends Model
+{
+    protected $fillable = [
+        'prefix',
+        'order_type', 
+        'year',
+        'current_sequence'
+    ];
+
+    /**
+     * Generate the next PO number atomically for the given order type and year.
+     * 
+     * @param string $orderType
+     * @param int $year
+     * @return string
+     */
+    public static function getNextPoNumber(string $orderType, int $year): string
+    {
+        $prefix = match($orderType) {
+            'branch_request' => "BR-{$year}-",
+            'purchase_order' => "PO-{$year}-",
+            default => "PO-{$year}-"
+        };
+
+        return DB::transaction(function () use ($prefix, $orderType, $year) {
+            // Use raw SQL with FOR UPDATE to ensure atomic increment
+            $sequence = DB::table('po_number_sequences')
+                ->where('prefix', $prefix)
+                ->where('order_type', $orderType)
+                ->where('year', $year)
+                ->lockForUpdate()
+                ->first();
+
+            if (!$sequence) {
+                // Create new sequence record if it doesn't exist
+                DB::table('po_number_sequences')->insert([
+                    'prefix' => $prefix,
+                    'order_type' => $orderType,
+                    'year' => $year,
+                    'current_sequence' => 1,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+                $nextSequence = 1;
+            } else {
+                // Increment the sequence atomically
+                $nextSequence = $sequence->current_sequence + 1;
+                DB::table('po_number_sequences')
+                    ->where('id', $sequence->id)
+                    ->update([
+                        'current_sequence' => $nextSequence,
+                        'updated_at' => now(),
+                    ]);
+            }
+
+            return $prefix . str_pad($nextSequence, 4, '0', STR_PAD_LEFT);
+        });
+    }
+}

--- a/database/migrations/2025_09_18_091200_create_po_number_sequences_table.php
+++ b/database/migrations/2025_09_18_091200_create_po_number_sequences_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('po_number_sequences', function (Blueprint $table) {
+            $table->id();
+            $table->string('prefix', 20); // e.g., 'BR-2025-', 'PO-2025-'
+            $table->string('order_type', 50); // e.g., 'branch_request', 'purchase_order'
+            $table->integer('year');
+            $table->integer('current_sequence')->default(0);
+            $table->timestamps();
+            
+            // Ensure unique combination of prefix, order_type, and year
+            $table->unique(['prefix', 'order_type', 'year']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('po_number_sequences');
+    }
+};


### PR DESCRIPTION
Implement atomic PO number generation to fix unique constraint violations caused by race conditions.

The previous PO number generation logic was prone to race conditions, where concurrent requests could generate the same PO number, leading to `Duplicate entry` errors. This PR introduces a dedicated `po_number_sequences` table and an atomic sequence generation mechanism using `DB::transaction` and `lockForUpdate()` to ensure unique PO numbers even under high concurrency.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d69f156-b2aa-4bd2-8f03-88378f1494c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d69f156-b2aa-4bd2-8f03-88378f1494c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

