### PR TITLE
Handle stock movement data truncation error

### DIFF
--- a/app/Models/StockMovement.php
+++ b/app/Models/StockMovement.php
@@ -126,7 +126,7 @@ class StockMovement extends Model
      */
     public function isIncoming(): bool
     {
-        return in_array($this->type, ['purchase', 'return', 'adjustment', 'transfer_in']);
+        return in_array($this->type, ['purchase', 'return', 'adjustment', 'adjustment_positive', 'transfer_in']);
     }
 
     /**
@@ -134,7 +134,7 @@ class StockMovement extends Model
      */
     public function isOutgoing(): bool
     {
-        return in_array($this->type, ['sale', 'loss', 'transfer_out', 'wastage']);
+        return in_array($this->type, ['sale', 'loss', 'adjustment_negative', 'transfer_out', 'wastage']);
     }
 
     /**
@@ -146,6 +146,8 @@ class StockMovement extends Model
             'purchase' => 'Purchase',
             'sale' => 'Sale',
             'adjustment' => 'Adjustment',
+            'adjustment_positive' => 'Positive Adjustment',
+            'adjustment_negative' => 'Negative Adjustment',
             'loss' => 'Loss',
             'return' => 'Return',
             'transfer_in' => 'Transfer In',

--- a/database/migrations/2025_01_17_000001_enhance_stock_movements_and_add_missing_fields.php
+++ b/database/migrations/2025_01_17_000001_enhance_stock_movements_and_add_missing_fields.php
@@ -35,8 +35,8 @@ return new class extends Migration
         
         Schema::table('stock_movements', function (Blueprint $table) {
             $table->enum('type', [
-                'purchase', 'sale', 'adjustment', 'loss', 'return', 
-                'transfer_in', 'transfer_out', 'wastage', 'complimentary'
+                'purchase', 'sale', 'adjustment', 'adjustment_positive', 'adjustment_negative', 
+                'loss', 'return', 'transfer_in', 'transfer_out', 'wastage', 'complimentary'
             ])->after('batch_id');
         });
 

--- a/fix_stock_movements_immediate.sql
+++ b/fix_stock_movements_immediate.sql
@@ -11,5 +11,12 @@ ADD COLUMN IF NOT EXISTS `movement_date` TIMESTAMP NULL AFTER `reference_id`;
 ALTER TABLE `stock_movements` 
 ADD INDEX IF NOT EXISTS `stock_movements_reference_type_reference_id_index` (`reference_type`, `reference_id`);
 
+-- Update the type enum to include adjustment_positive and adjustment_negative
+ALTER TABLE `stock_movements` 
+MODIFY COLUMN `type` ENUM(
+    'purchase', 'sale', 'adjustment', 'adjustment_positive', 'adjustment_negative', 
+    'loss', 'return', 'transfer_in', 'transfer_out', 'wastage', 'complimentary'
+) NOT NULL;
+
 -- Check if columns were added successfully
 SHOW COLUMNS FROM `stock_movements`;

--- a/fix_stock_movements_schema.sql
+++ b/fix_stock_movements_schema.sql
@@ -25,8 +25,8 @@ AFTER reference_id;
 -- First, we need to modify the existing enum
 ALTER TABLE stock_movements 
 MODIFY COLUMN type ENUM(
-    'purchase', 'sale', 'adjustment', 'loss', 'return', 
-    'transfer_in', 'transfer_out', 'wastage', 'complimentary'
+    'purchase', 'sale', 'adjustment', 'adjustment_positive', 'adjustment_negative', 
+    'loss', 'return', 'transfer_in', 'transfer_out', 'wastage', 'complimentary'
 ) NOT NULL;
 
 -- Add indexes for better performance


### PR DESCRIPTION
Add `adjustment_positive` and `adjustment_negative` to the `stock_movements.type` enum and update related logic to resolve data truncation errors during stock adjustments.

The `stock_movements.type` column was an ENUM that lacked `adjustment_positive` and `adjustment_negative`. This caused a `Data truncated` error when the system attempted to record stock movements for weight differences (e.g., `adjustment_negative` for actual weight < expected weight) during material receipt. This PR expands the enum and updates the model to correctly handle these specific adjustment types.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ee8cec7-8593-47b3-a558-de758724f2ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ee8cec7-8593-47b3-a558-de758724f2ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

