### PR TITLE
Process purchase form and update aggregates

### DIFF
--- a/app/Http/Controllers/LocalPurchaseController.php
+++ b/app/Http/Controllers/LocalPurchaseController.php
@@ -118,7 +118,7 @@ class LocalPurchaseController extends Controller
 
         $validated = $request->validate([
             'vendor_id' => 'nullable|exists:vendors,id',
-            'vendor_name' => 'required_without:vendor_id|string|max:255',
+            'vendor_name' => 'required_without:vendor_id|nullable|string|max:255',
             'vendor_phone' => 'nullable|string|max:20',
             'purchase_date' => 'required|date',
             'payment_method' => ['required', Rule::in(['cash', 'upi', 'credit', 'bank_transfer', 'card', 'other'])],
@@ -264,7 +264,7 @@ class LocalPurchaseController extends Controller
 
         $validated = $request->validate([
             'vendor_id' => 'nullable|exists:vendors,id',
-            'vendor_name' => 'required_without:vendor_id|string|max:255',
+            'vendor_name' => 'required_without:vendor_id|nullable|string|max:255',
             'vendor_phone' => 'nullable|string|max:20',
             'purchase_date' => 'required|date',
             'payment_method' => ['required', Rule::in(['cash', 'upi', 'credit', 'bank_transfer', 'card', 'other'])],

--- a/resources/views/local-purchases/create.blade.php
+++ b/resources/views/local-purchases/create.blade.php
@@ -273,6 +273,9 @@ let itemCount = 0;
 document.addEventListener('DOMContentLoaded', function() {
     addItemRow();
     
+    // Initialize vendor field requirements
+    toggleVendorFields();
+    
     // Load purchase order items if selected
     const purchaseOrderId = document.querySelector('[name="purchase_order_id"]').value;
     if (purchaseOrderId && '{{ $selectedOrder }}') {
@@ -289,8 +292,12 @@ function toggleVendorFields() {
     if (useExisting) {
         document.querySelector('[name="vendor_name"]').value = '';
         document.querySelector('[name="vendor_phone"]').value = '';
+        // Make sure vendor_name is not required when using existing vendor
+        document.querySelector('[name="vendor_name"]').removeAttribute('required');
     } else {
         document.querySelector('[name="vendor_id"]').value = '';
+        // Make vendor_name required when using new vendor
+        document.querySelector('[name="vendor_name"]').setAttribute('required', 'required');
     }
 }
 
@@ -475,6 +482,8 @@ document.getElementById('localPurchaseForm').addEventListener('submit', function
             alert('Please select a vendor');
             return false;
         }
+        // Clear vendor_name when using existing vendor to avoid validation issues
+        document.querySelector('[name="vendor_name"]').value = '';
     } else {
         const vendorName = document.querySelector('[name="vendor_name"]').value;
         if (!vendorName) {


### PR DESCRIPTION
Allow `vendor_name` to be nullable when an existing `vendor_id` is provided to fix a validation error on the local purchase form.

The previous validation rule for `vendor_name` incorrectly applied the `string` rule to a `null` value when an existing `vendor_id` was selected, leading to "The vendor name field must be a string" error. This PR adds `nullable` to the server-side validation and updates client-side JavaScript to correctly manage the `vendor_name` field's requirement and value based on vendor selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d9ef96a-02bc-4860-a755-3008633ff4de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d9ef96a-02bc-4860-a755-3008633ff4de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

