### PR TITLE
Add local purchase request to admin sidebar

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -417,6 +417,19 @@
                 </div>
                 <span class="font-medium">Orders from Branches</span>
             </a>
+            
+            <a href="{{ route('admin.local-purchases.index') }}" class="nav-link flex items-center p-3 rounded-xl text-gray-300 {{ request()->routeIs('admin.local-purchases.*') ? 'active text-white' : '' }}">
+                <div class="nav-icon rounded-lg flex items-center justify-center mr-3">
+                    <i class="fas fa-shopping-basket"></i>
+                </div>
+                <span class="font-medium">Local Purchase Requests</span>
+                @php
+                    $pendingCount = \App\Models\LocalPurchase::where('status', 'pending')->count();
+                @endphp
+                @if($pendingCount > 0)
+                    <span class="ml-auto bg-red-500 text-white text-xs px-2 py-1 rounded-full">{{ $pendingCount }}</span>
+                @endif
+            </a>
             @endif
             
             <a href="{{ route('reports.index') }}" class="nav-link flex items-center p-3 rounded-xl text-gray-300 {{ request()->routeIs('reports.*') ? 'active text-white' : '' }}">


### PR DESCRIPTION
Add "Local Purchase Requests" to the admin sidebar to make it accessible for admin users.

---
<a href="https://cursor.com/background-agent?bcId=bc-2aee057b-2b6b-41eb-a873-aad6001606d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2aee057b-2b6b-41eb-a873-aad6001606d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

