### PR TITLE
Make sidebars scrollable for accessibility

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -339,7 +339,7 @@
     <div id="mobile-overlay" class="fixed inset-0 bg-black/50 z-1000 hidden lg:hidden" onclick="toggleMobileMenu()"></div>
     
     <!-- Sidebar -->
-    <div id="sidebar" class="sidebar fixed left-0 top-0 h-full w-80 text-white">
+    <div id="sidebar" class="sidebar fixed left-0 top-0 h-full w-80 text-white flex flex-col">
         <!-- Logo Section -->
         <div class="p-6 text-center border-b border-white/20">
             <div class="logo-icon w-16 h-16 mx-auto mb-4 rounded-2xl flex items-center justify-center">
@@ -354,12 +354,12 @@
         </div>
         
         <!-- Navigation -->
-        <div class="flex-1 overflow-y-auto pb-24">
+        <div class="flex-1 min-h-0 overflow-y-auto">
             @include('partials.navigation.super-admin')
         </div>
         
         <!-- User Profile -->
-        <div class="absolute bottom-0 left-0 right-0 p-6 border-t border-white/20 bg-black/30">
+        <div class="mt-auto p-6 border-t border-white/20 bg-black/30">
             <div class="flex items-center space-x-3">
                 <div class="w-12 h-12 bg-gradient-to-br from-amber-400 to-orange-500 rounded-xl flex items-center justify-center shadow-lg">
                     <span class="text-white font-bold">{{ strtoupper(substr(auth()->user()->name ?? 'SA', 0, 2)) }}</span>

--- a/resources/views/layouts/branch-manager.blade.php
+++ b/resources/views/layouts/branch-manager.blade.php
@@ -119,7 +119,7 @@
     <div id="mobile-overlay" class="fixed inset-0 bg-black/50 z-1000 hidden lg:hidden" onclick="toggleMobileMenu()"></div>
     
     <!-- Sidebar -->
-    <div id="sidebar" class="sidebar fixed left-0 top-0 h-full w-80 text-white z-50">
+    <div id="sidebar" class="sidebar fixed left-0 top-0 h-full w-80 text-white z-50 flex flex-col">
         <!-- Logo Section -->
         <div class="p-6 text-center border-b border-white/20">
             <div class="logo-icon w-16 h-16 mx-auto mb-4 rounded-2xl flex items-center justify-center">
@@ -150,12 +150,12 @@
         @endif
         
         <!-- Navigation -->
-        <div class="flex-1 overflow-y-auto pb-24">
+        <div class="flex-1 min-h-0 overflow-y-auto">
             @include('partials.navigation.branch-manager')
         </div>
         
         <!-- User Profile -->
-        <div class="absolute bottom-0 left-0 right-0 p-6 border-t border-white/20 bg-black/30">
+        <div class="mt-auto p-6 border-t border-white/20 bg-black/30">
             <div class="flex items-center space-x-3">
                 <div class="w-12 h-12 bg-gradient-to-br from-green-400 to-emerald-500 rounded-xl flex items-center justify-center shadow-lg">
                     <span class="text-white font-bold">{{ strtoupper(substr(auth()->user()->name ?? 'BM', 0, 2)) }}</span>

--- a/resources/views/layouts/cashier.blade.php
+++ b/resources/views/layouts/cashier.blade.php
@@ -134,7 +134,7 @@
     <div id="mobile-overlay" class="fixed inset-0 bg-black/50 z-1000 hidden lg:hidden" onclick="toggleMobileMenu()"></div>
     
     <!-- Sidebar -->
-    <div id="sidebar" class="sidebar fixed left-0 top-0 h-full w-80 text-white z-50">
+    <div id="sidebar" class="sidebar fixed left-0 top-0 h-full w-80 text-white z-50 flex flex-col">
         <!-- Logo Section -->
         <div class="p-6 text-center border-b border-white/20">
             <div class="logo-icon w-16 h-16 mx-auto mb-4 rounded-2xl flex items-center justify-center">
@@ -178,12 +178,12 @@
         </div>
         
         <!-- Navigation -->
-        <div class="flex-1 overflow-y-auto pb-24">
+        <div class="flex-1 min-h-0 overflow-y-auto">
             @include('partials.navigation.cashier')
         </div>
         
         <!-- User Profile -->
-        <div class="absolute bottom-0 left-0 right-0 p-6 border-t border-white/20 bg-black/30">
+        <div class="mt-auto p-6 border-t border-white/20 bg-black/30">
             <div class="flex items-center space-x-3">
                 <div class="w-12 h-12 bg-gradient-to-br from-purple-400 to-indigo-500 rounded-xl flex items-center justify-center shadow-lg">
                     <span class="text-white font-bold">{{ strtoupper(substr(auth()->user()->name ?? 'C', 0, 1)) }}</span>

--- a/resources/views/layouts/super-admin.blade.php
+++ b/resources/views/layouts/super-admin.blade.php
@@ -113,7 +113,7 @@
     <div id="mobile-overlay" class="fixed inset-0 bg-black/50 z-1000 hidden lg:hidden" onclick="toggleMobileMenu()"></div>
     
     <!-- Sidebar -->
-    <div id="sidebar" class="sidebar fixed left-0 top-0 h-full w-80 text-white z-50">
+    <div id="sidebar" class="sidebar fixed left-0 top-0 h-full w-80 text-white z-50 flex flex-col">
         <!-- Logo Section -->
         <div class="p-6 text-center border-b border-white/20">
             <div class="logo-icon w-16 h-16 mx-auto mb-4 rounded-2xl flex items-center justify-center">
@@ -128,12 +128,12 @@
         </div>
         
         <!-- Navigation -->
-        <div class="flex-1 overflow-y-auto pb-24">
+        <div class="flex-1 min-h-0 overflow-y-auto">
             @include('partials.navigation.super-admin')
         </div>
         
         <!-- User Profile -->
-        <div class="absolute bottom-0 left-0 right-0 p-6 border-t border-white/20 bg-black/30">
+        <div class="mt-auto p-6 border-t border-white/20 bg-black/30">
             <div class="flex items-center space-x-3">
                 <div class="w-12 h-12 bg-gradient-to-br from-amber-400 to-orange-500 rounded-xl flex items-center justify-center shadow-lg">
                     <span class="text-white font-bold">{{ strtoupper(substr(auth()->user()->name ?? 'SA', 0, 2)) }}</span>


### PR DESCRIPTION
Refactor sidebar layouts to enable scrolling and access to bottom elements by using flexbox and removing absolute positioning.

The previous fixed-position sidebar with an absolutely positioned bottom user profile prevented the navigation section from scrolling, making lower elements inaccessible. This PR converts the sidebar to a flex column, allows the navigation to shrink and scroll, and positions the user profile using `margin-top: auto`.

---
<a href="https://cursor.com/background-agent?bcId=bc-7af3e22c-1df2-493e-b1e7-e74bd5adcabd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7af3e22c-1df2-493e-b1e7-e74bd5adcabd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

