### PR TITLE
Fix enum parsing error in local purchase model

### DIFF
--- a/app/Models/LocalPurchase.php
+++ b/app/Models/LocalPurchase.php
@@ -340,7 +340,8 @@ class LocalPurchase extends Model
             'card' => 'card',
             'bank_transfer', 'bank' => 'bank',
             // 'credit' or 'other' will be treated as bank for accounting entry
-            'credit', 'other', default => 'bank',
+            'credit', 'other' => 'bank',
+            default => 'bank',
         };
     }
 }


### PR DESCRIPTION
Fixes a PHP `ParseError` in `LocalPurchase.php` by correcting the syntax of a `match` expression.

The original `match` expression had an invalid syntax for combining multiple conditions with a `default` case, causing an "unexpected token 'default', expecting '=>'" error. This PR separates the `default` case and correctly groups multiple conditions for the same result.

---
<a href="https://cursor.com/background-agent?bcId=bc-995fbf82-f0cf-4fd8-8b9f-67b7d5b7cc26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-995fbf82-f0cf-4fd8-8b9f-67b7d5b7cc26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

