### PR TITLE
Fix branch manager reports functionality

### DIFF
--- a/resources/views/reports/analytics.blade.php
+++ b/resources/views/reports/analytics.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.app')
+
+@section('title', 'Analytics')
+
+@section('content')
+<div class="container mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold text-gray-900 mb-6">Analytics</h1>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div class="bg-white rounded-lg shadow p-4">
+            <h2 class="text-lg font-semibold mb-3">Top Selling Products</h2>
+            <ul class="divide-y">
+                @forelse(($topProducts ?? []) as $product)
+                <li class="py-2 flex justify-between">
+                    <span>{{ $product->name }}</span>
+                    <span class="font-semibold">{{ number_format($product->total_sold) }}</span>
+                </li>
+                @empty
+                <li class="py-2 text-gray-500">No data</li>
+                @endforelse
+            </ul>
+        </div>
+        <div class="bg-white rounded-lg shadow p-4">
+            <h2 class="text-lg font-semibold mb-3">Sales by Category</h2>
+            <ul class="divide-y">
+                @forelse(($salesByCategory ?? []) as $item)
+                <li class="py-2 flex justify-between">
+                    <span>{{ $item->category }}</span>
+                    <span class="font-semibold">{{ number_format($item->total_sold) }}</span>
+                </li>
+                @empty
+                <li class="py-2 text-gray-500">No data</li>
+                @endforelse
+            </ul>
+        </div>
+    </div>
+</div>
+@endsection
+

--- a/resources/views/reports/customers.blade.php
+++ b/resources/views/reports/customers.blade.php
@@ -1,0 +1,59 @@
+@extends('layouts.app')
+
+@section('title', 'Customer Reports')
+
+@section('content')
+<div class="container mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold text-gray-900 mb-6">Customer Reports</h1>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+        <div class="bg-white rounded-lg shadow p-4">
+            <h2 class="text-lg font-semibold mb-3">Top Customers</h2>
+            <ul class="divide-y">
+                @forelse(($topCustomers ?? []) as $customer)
+                <li class="py-2 flex justify-between">
+                    <span>{{ $customer->name }}</span>
+                    <span class="font-semibold">₹{{ number_format($customer->orders_sum_total_amount, 2) }}</span>
+                </li>
+                @empty
+                <li class="py-2 text-gray-500">No data</li>
+                @endforelse
+            </ul>
+        </div>
+        <div class="bg-white rounded-lg shadow p-4">
+            <h2 class="text-lg font-semibold mb-3">Summary</h2>
+            <p class="text-gray-600">This section summarizes purchase totals per customer.</p>
+        </div>
+    </div>
+
+    <div class="table-container overflow-x-auto">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Total Orders</th>
+                    <th>Total Spent</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse(($customers ?? []) as $customer)
+                <tr>
+                    <td>{{ $customer->name }}</td>
+                    <td>{{ number_format($customer->orders_count) }}</td>
+                    <td>₹{{ number_format($customer->orders_sum_total_amount, 2) }}</td>
+                </tr>
+                @empty
+                <tr>
+                    <td colspan="3" class="text-center text-gray-500 p-4">No customers</td>
+                </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-4">
+        {{ method_exists(($customers ?? null), 'links') ? $customers->links() : '' }}
+    </div>
+</div>
+@endsection
+

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -157,12 +157,14 @@
                         </svg>
                         <span class="text-orange-900">Vendor Performance</span>
                     </a>
+                    @if(auth()->check() && (auth()->user()->hasRole('super_admin') || auth()->user()->hasRole('admin')))
                     <a href="{{ route('vendors.purchaseOrders') }}" class="flex items-center p-3 rounded-lg hover:bg-orange-50 transition-colors">
                         <svg class="h-5 w-5 text-orange-600 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                         </svg>
                         <span class="text-orange-900">Purchase Orders</span>
                     </a>
+                    @endif
                 </div>
             </div>
         </div>

--- a/resources/views/reports/inventory.blade.php
+++ b/resources/views/reports/inventory.blade.php
@@ -1,0 +1,56 @@
+@extends('layouts.app')
+
+@section('title', 'Inventory Report')
+
+@section('content')
+<div class="container mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold text-gray-900 mb-6">Inventory Report</h1>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div class="bg-white rounded-lg shadow p-4">
+            <p class="text-sm text-gray-500">Products with Stock</p>
+            <p class="text-2xl font-semibold text-gray-900">{{ number_format(($products ?? collect())->count()) }}</p>
+        </div>
+        <div class="bg-white rounded-lg shadow p-4">
+            <p class="text-sm text-gray-500">Low Stock Products</p>
+            <p class="text-2xl font-semibold text-gray-900">{{ number_format(($lowStockProducts ?? collect())->count()) }}</p>
+        </div>
+        <div class="bg-white rounded-lg shadow p-4">
+            <p class="text-sm text-gray-500">Estimated Inventory Value</p>
+            <p class="text-2xl font-semibold text-gray-900">₹{{ number_format($totalValue ?? 0, 2) }}</p>
+        </div>
+    </div>
+
+    <div class="table-container overflow-x-auto">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Product</th>
+                    <th>Branch</th>
+                    <th>Stock</th>
+                    <th>Selling Price</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse(($products ?? collect()) as $product)
+                    @foreach(($product->branches ?? collect()) as $branch)
+                    <tr>
+                        <td>{{ $product->name }}</td>
+                        <td>{{ $branch->name }}</td>
+                        <td>{{ $branch->pivot->current_stock }}</td>
+                        <td>₹{{ number_format($branch->pivot->selling_price, 2) }}</td>
+                        <td>₹{{ number_format($branch->pivot->current_stock * $branch->pivot->selling_price, 2) }}</td>
+                    </tr>
+                    @endforeach
+                @empty
+                <tr>
+                    <td colspan="5" class="text-center text-gray-500 p-4">No inventory data</td>
+                </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+</div>
+@endsection
+

--- a/resources/views/reports/profit-loss.blade.php
+++ b/resources/views/reports/profit-loss.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app')
+
+@section('title', 'Profit & Loss')
+
+@section('content')
+<div class="container mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold text-gray-900 mb-6">Profit & Loss</h1>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div class="bg-white rounded-lg shadow p-4">
+            <p class="text-sm text-gray-500">Total Revenue</p>
+            <p class="text-2xl font-semibold text-gray-900">₹{{ number_format($totalRevenue ?? 0, 2) }}</p>
+        </div>
+        <div class="bg-white rounded-lg shadow p-4">
+            <p class="text-sm text-gray-500">Estimated Costs</p>
+            <p class="text-2xl font-semibold text-gray-900">₹{{ number_format($estimatedCosts ?? 0, 2) }}</p>
+        </div>
+        <div class="bg-white rounded-lg shadow p-4">
+            <p class="text-sm text-gray-500">Gross Profit</p>
+            <p class="text-2xl font-semibold text-gray-900">₹{{ number_format($grossProfit ?? 0, 2) }}</p>
+        </div>
+    </div>
+</div>
+@endsection
+

--- a/resources/views/reports/sales.blade.php
+++ b/resources/views/reports/sales.blade.php
@@ -1,0 +1,117 @@
+@extends('layouts.app')
+
+@section('title', 'Sales Report')
+
+@section('content')
+<div class="container mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold text-gray-900 mb-6">Sales Report</h1>
+
+    <div class="bg-white rounded-lg shadow p-4 mb-6">
+        <form method="GET" action="{{ route('reports.sales') }}" class="grid grid-cols-1 md:grid-cols-4 gap-4">
+            @csrf
+            <div>
+                <label class="form-label">Start date</label>
+                <input type="date" name="start_date" value="{{ request('start_date') }}" class="form-input">
+            </div>
+            <div>
+                <label class="form-label">End date</label>
+                <input type="date" name="end_date" value="{{ request('end_date') }}" class="form-input">
+            </div>
+            @if(isset($branches) && $branches->count() > 1)
+            <div>
+                <label class="form-label">Branch</label>
+                <select name="branch_id" class="form-input">
+                    <option value="">All</option>
+                    @foreach($branches as $branch)
+                        <option value="{{ $branch->id }}" {{ request('branch_id') == $branch->id ? 'selected' : '' }}>{{ $branch->name }}</option>
+                    @endforeach
+                </select>
+            </div>
+            @endif
+            <div class="flex items-end">
+                <button class="btn btn-primary" type="submit">Filter</button>
+            </div>
+        </form>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div class="bg-white rounded-lg shadow p-4">
+            <p class="text-sm text-gray-500">Total Orders (page)</p>
+            <p class="text-2xl font-semibold text-gray-900">{{ number_format($totalOrders ?? 0) }}</p>
+        </div>
+        <div class="bg-white rounded-lg shadow p-4">
+            <p class="text-sm text-gray-500">Total Sales (page)</p>
+            <p class="text-2xl font-semibold text-gray-900">₹{{ number_format($totalSales ?? 0, 2) }}</p>
+        </div>
+        @if(isset($branchSummary) && count($branchSummary))
+        <div class="bg-white rounded-lg shadow p-4">
+            <p class="text-sm text-gray-500">Top Branch</p>
+            @php $top = $branchSummary->first(); @endphp
+            <p class="text-2xl font-semibold text-gray-900">{{ $top?->branch?->name ?? '-' }}</p>
+        </div>
+        @endif
+    </div>
+
+    <div class="table-container overflow-x-auto">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Order</th>
+                    <th>Customer</th>
+                    <th>Branch</th>
+                    <th>Total</th>
+                    <th>Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse(($orders ?? []) as $order)
+                <tr>
+                    <td>{{ $loop->iteration }}</td>
+                    <td>#{{ $order->id }}</td>
+                    <td>{{ $order->customer->name ?? 'Walk-in' }}</td>
+                    <td>{{ $order->branch->name ?? '-' }}</td>
+                    <td>₹{{ number_format($order->total_amount, 2) }}</td>
+                    <td>{{ $order->created_at->format('Y-m-d H:i') }}</td>
+                </tr>
+                @empty
+                <tr>
+                    <td colspan="6" class="text-center text-gray-500 p-4">No orders found</td>
+                </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-4">
+        {{ method_exists(($orders ?? null), 'links') ? $orders->links() : '' }}
+    </div>
+
+    @if(isset($branchSummary) && count($branchSummary))
+    <div class="bg-white rounded-lg shadow p-4 mt-6">
+        <h2 class="text-xl font-semibold mb-3">Branch Summary</h2>
+        <div class="overflow-x-auto">
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Branch</th>
+                        <th>Orders</th>
+                        <th>Total Sales</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($branchSummary as $summary)
+                    <tr>
+                        <td>{{ $summary->branch->name ?? '-' }}</td>
+                        <td>{{ number_format($summary->order_count) }}</td>
+                        <td>₹{{ number_format($summary->total_sales, 2) }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+    @endif
+</div>
+@endsection
+

--- a/resources/views/reports/vendors.blade.php
+++ b/resources/views/reports/vendors.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.app')
+
+@section('title', 'Vendor Reports')
+
+@section('content')
+<div class="container mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold text-gray-900 mb-6">Vendor Reports</h1>
+
+    <div class="table-container overflow-x-auto">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Vendor</th>
+                    <th>PO Count</th>
+                    <th>Total Amount</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse(($vendors ?? []) as $vendor)
+                <tr>
+                    <td>{{ $vendor->name }}</td>
+                    <td>{{ number_format($vendor->purchase_orders_count) }}</td>
+                    <td>₹{{ number_format($vendor->purchase_orders_sum_total_amount, 2) }}</td>
+                </tr>
+                @empty
+                <tr>
+                    <td colspan="3" class="text-center text-gray-500 p-4">No vendor data</td>
+                </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-4">
+        {{ method_exists(($vendors ?? null), 'links') ? $vendors->links() : '' }}
+    </div>
+</div>
+@endsection
+


### PR DESCRIPTION
Create missing branch report views and conditionally hide the "Vendor Purchase Orders" link for branch managers to make all report options functional.

The previous implementation of branch reports resulted in "View not found" errors for all options, rendering the page unusable for branch managers. This PR adds the necessary Blade view files for sales, inventory, customers, vendors, profit-loss, and analytics reports, and also restricts the "Vendor Purchase Orders" link to admin roles.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d264e00-aeb3-419b-8344-72b238fffa4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d264e00-aeb3-419b-8344-72b238fffa4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

