### PR TITLE
Fix unknown column in product analytics query

### DIFF
--- a/app/Http/Controllers/Web/ReportController.php
+++ b/app/Http/Controllers/Web/ReportController.php
@@ -222,10 +222,11 @@ class ReportController extends Controller
             ->take(10)
             ->get();
 
-        // Get sales by category
-        $salesByCategory = Product::withCount(['orderItems as total_sold'])
-            ->selectRaw('category, SUM(order_items_count) as total_sold')
-            ->groupBy('category')
+        // Get sales by category - fix the query to properly count order items
+        $salesByCategory = Product::join('order_items', 'products.id', '=', 'order_items.product_id')
+            ->selectRaw('products.category, COUNT(order_items.id) as total_sold')
+            ->groupBy('products.category')
+            ->orderBy('total_sold', 'desc')
             ->get();
 
         return view('reports.analytics', compact('topProducts', 'salesByCategory'));


### PR DESCRIPTION
Refactor `salesByCategory` query to fix "Unknown column 'order_items_count'" SQL error.

---
<a href="https://cursor.com/background-agent?bcId=bc-acbea9e8-433c-472b-b32b-3228e9bb7485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-acbea9e8-433c-472b-b32b-3228e9bb7485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

