### PR TITLE
Fix undefined pos session current method

### DIFF
--- a/app/Http/Controllers/Web/PosSessionController.php
+++ b/app/Http/Controllers/Web/PosSessionController.php
@@ -276,6 +276,31 @@ class PosSessionController extends Controller
     }
 
     /**
+     * Handle current session - redirect to active session or create new one.
+     */
+    public function current()
+    {
+        $user = auth()->user();
+        $branch = $user->branch;
+
+        if (!$branch) {
+            return redirect()->route('dashboard')->with('error', 'No branch assigned to your account.');
+        }
+
+        // Check if user has an active session
+        $activeSession = $user->currentPosSession();
+        
+        if ($activeSession) {
+            // Redirect to the active session
+            return redirect()->route('pos.sessions.show', $activeSession);
+        } else {
+            // No active session, redirect to create new one
+            return redirect()->route('pos.sessions.create')
+                ->with('info', 'You don\'t have an active POS session. Please start a new session.');
+        }
+    }
+
+    /**
      * Get active sessions for branch management.
      */
     public function getActiveSessions()


### PR DESCRIPTION
Implement missing `current()` method in `PosSessionController` to resolve `Undefined method` error for the current POS session route.

---
<a href="https://cursor.com/background-agent?bcId=bc-d21057f1-f992-4bab-b83f-e5e1eb8f32b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d21057f1-f992-4bab-b83f-e5e1eb8f32b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

