### PR TITLE
Fix undefined product variable in low stock view

### DIFF
--- a/resources/views/inventory/low-stock-alerts.blade.php
+++ b/resources/views/inventory/low-stock-alerts.blade.php
@@ -51,7 +51,7 @@
             <div class="flex items-center justify-between">
                 <div>
                     <p class="text-orange-100 text-sm font-medium">Critical Stock Items</p>
-                    <p class="text-2xl font-bold">{{ $lowStockProducts->filter(function($product) { return $product->branches->some(function($branch) { return $branch->pivot->current_stock <= ($product->stock_threshold * 0.5); }); })->count() }}</p>
+                    <p class="text-2xl font-bold">{{ $lowStockProducts->filter(function($product) { return $product->branches->some(function($branch) use ($product) { return $branch->pivot->current_stock <= ($product->stock_threshold * 0.5); }); })->count() }}</p>
                 </div>
                 <div class="bg-white/20 p-3 rounded-lg">
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -66,7 +66,7 @@
                 <div>
                     <p class="text-yellow-100 text-sm font-medium">Potential Revenue Loss</p>
                     <p class="text-2xl font-bold">₹{{ number_format($lowStockProducts->sum(function($product) { 
-                        return $product->branches->sum(function($branch) { 
+                        return $product->branches->sum(function($branch) use ($product) { 
                             return ($product->stock_threshold - $branch->pivot->current_stock) * $branch->pivot->selling_price; 
                         }); 
                     }), 2) }}</p>


### PR DESCRIPTION
Fix 'Undefined variable $product' error in `low-stock-alerts.blade.php`.

The `$product` variable was not accessible within nested closures, causing an `ErrorException`. This was resolved by explicitly passing `$product` to the inner closures using the `use` keyword, ensuring proper variable scoping.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1abf46f-20f8-438a-8e3c-cb74f4ab01d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f1abf46f-20f8-438a-8e3c-cb74f4ab01d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

